### PR TITLE
FSA22V2-216: Add support for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Basic dependabot.yml file with
+# minimum configuration for npm
+
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
### Description:
<!-- Add description of work done here -->
Add dependabot.yml file to check for weekly npm updates to dependencies. This file is in the `.github` folder, named `dependabot.yml`. 

### Spec:

See Story: [FSA22V2-216](https://sparkbox.atlassian.net/browse/FSA22V2-216)

### Validation:
<!-- Add description of work done here -->

* [x] This PR has code changes, and our linters still pass.

#### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
3. Confirm `dependabot.yml` file: 
    a. is valid
    b. is named correctly
    c. lives in the correct place in this repo

<!-- Additional validation steps below -->

---

### Pending Questions
1. As Quinn mentioned in a comment, should we add an `open-pull-request-limit` to the dependabot file at all? What would the limit be? 
2. Similarly, should we be more specific about the schedule (day and/or time) that the update checks run? Is there a better or worse day? 
3. Since Sparkbox has specific branch naming strategies, should we utilize `pull-request-branch-name.separator` to make sure those created branches are consistent?
4. Quinn mentioned potentially needing to add `allow: - dependency-name: "react*` because React is a dependency. Is this already done by default?
