### PR TITLE
FSA22V2-279: Update to Next13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "check-node-version": "^4.2.1",
         "isomorphic-dompurify": "^0.23.0",
         "marked": "^4.1.1",
-        "next": "12.3.1",
+        "next": "^13.0.1",
         "react": "18.2.0",
         "react-dom": "18.2.0"
       },
@@ -23,7 +23,7 @@
         "check-node-version": "^4.2.1",
         "eslint": "8.26.0",
         "eslint-config-airbnb": "^19.0.4",
-        "eslint-config-next": "12.3.1",
+        "eslint-config-next": "^13.0.1",
         "husky": "^8.0.1",
         "jest": "^29.2.2",
         "jest-environment-jsdom": "^29.2.2",
@@ -1259,21 +1259,23 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "12.3.1",
-      "license": "MIT"
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.0.1.tgz",
+      "integrity": "sha512-gK60YoFae3s8qi5UgIzbvxOhsh5gKyEaiKH5+kLBUYXLlrPyWJR2xKBj2WqvHkO7wDX7/Hed3DAqjSpU4ijIvQ=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "12.3.1",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.0.1.tgz",
+      "integrity": "sha512-t3bggJhKE/oB4pvMM7hMNnmIpIqsMGJ+OLklk8llOkSeXtfCV+MBQbhImWxf5QODkxNAmMK3IJGAAecQhBTc/Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "glob": "7.1.7"
       }
     },
     "node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.1.tgz",
-      "integrity": "sha512-i+BvKA8tB//srVPPQxIQN5lvfROcfv4OB23/L1nXznP+N/TyKL8lql3l7oo2LNhnH66zWhfoemg3Q4VJZSruzQ==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.1.tgz",
+      "integrity": "sha512-M28QSbohZlNXNn//HY6lV2T3YaMzG58Jwr0YwOdVmOQv6i+7lu6xe3GqQu4kdqInqhLrBXnL+nabFuGTVSHtTg==",
       "cpu": [
         "arm"
       ],
@@ -1286,9 +1288,9 @@
       }
     },
     "node_modules/@next/swc-android-arm64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.1.tgz",
-      "integrity": "sha512-CmgU2ZNyBP0rkugOOqLnjl3+eRpXBzB/I2sjwcGZ7/Z6RcUJXK5Evz+N0ucOxqE4cZ3gkTeXtSzRrMK2mGYV8Q==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.0.1.tgz",
+      "integrity": "sha512-szmO/i6GoHcPXcbhUKhwBMETWHNXH3ITz9wfxwOOFBNKdDU8pjKsHL88lg28aOiQYZSU1sxu1v1p9KY5kJIZCg==",
       "cpu": [
         "arm64"
       ],
@@ -1301,11 +1303,12 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "12.3.1",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.0.1.tgz",
+      "integrity": "sha512-O1RxCaiDNOjGZmdAp6SQoHUITt9aVDQXoR3lZ/TloI/NKRAyAV4u0KUUofK+KaZeHOmVTnPUaQuCyZSc3i1x5Q==",
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1315,11 +1318,11 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.1.tgz",
-      "integrity": "sha512-9S6EVueCVCyGf2vuiLiGEHZCJcPAxglyckTZcEwLdJwozLqN0gtS0Eq0bQlGS3dH49Py/rQYpZ3KVWZ9BUf/WA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.0.1.tgz",
+      "integrity": "sha512-8E6BY/VO+QqQkthhoWgB8mJMw1NcN9Vhl2OwEwxv8jy2r3zjeU+WNRxz4y8RLbcY0R1h+vHlXuP0mLnuac84tQ==",
       "cpu": [
-        "arm64"
+        "x64"
       ],
       "optional": true,
       "os": [
@@ -1330,9 +1333,9 @@
       }
     },
     "node_modules/@next/swc-freebsd-x64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.1.tgz",
-      "integrity": "sha512-qcuUQkaBZWqzM0F1N4AkAh88lLzzpfE6ImOcI1P6YeyJSsBmpBIV8o70zV+Wxpc26yV9vpzb+e5gCyxNjKJg5Q==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.0.1.tgz",
+      "integrity": "sha512-ocwoOxm2KVwF50RyoAT+2RQPLlkyoF7sAqzMUVgj+S6+DTkY3iwH+Zpo0XAk2pnqT9qguOrKnEpq9EIx//+K7Q==",
       "cpu": [
         "x64"
       ],
@@ -1345,9 +1348,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.1.tgz",
-      "integrity": "sha512-diL9MSYrEI5nY2wc/h/DBewEDUzr/DqBjIgHJ3RUNtETAOB3spMNHvJk2XKUDjnQuluLmFMloet9tpEqU2TT9w==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.0.1.tgz",
+      "integrity": "sha512-yO7e3zITfGol/N6lPQnmIRi0WyuILBMXrvH6EdmWzzqMDJFfTCII6l+B6gMO5WVDCTQUGQlQRNZ7sFqWR4I71g==",
       "cpu": [
         "arm"
       ],
@@ -1360,9 +1363,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.1.tgz",
-      "integrity": "sha512-o/xB2nztoaC7jnXU3Q36vGgOolJpsGG8ETNjxM1VAPxRwM7FyGCPHOMk1XavG88QZSQf+1r+POBW0tLxQOJ9DQ==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.0.1.tgz",
+      "integrity": "sha512-OEs6WDPDI8RyM8SjOqTDMqMBfOlU97VnW6ZMXUvzUTyH0K9c7NF+cn7UMu+I4tKFN0uJ9WQs/6TYaFBGkgoVVA==",
       "cpu": [
         "arm64"
       ],
@@ -1375,9 +1378,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.1.tgz",
-      "integrity": "sha512-2WEasRxJzgAmP43glFNhADpe8zB7kJofhEAVNbDJZANp+H4+wq+/cW1CdDi8DqjkShPEA6/ejJw+xnEyDID2jg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.0.1.tgz",
+      "integrity": "sha512-y5ypFK0Y3urZSFoQxbtDqvKsBx026sz+Fm+xHlPWlGHNZrbs3Q812iONjcZTo09QwRMk5X86iMWBRxV18xMhaw==",
       "cpu": [
         "arm64"
       ],
@@ -1390,9 +1393,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.1.tgz",
-      "integrity": "sha512-JWEaMyvNrXuM3dyy9Pp5cFPuSSvG82+yABqsWugjWlvfmnlnx9HOQZY23bFq3cNghy5V/t0iPb6cffzRWylgsA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.0.1.tgz",
+      "integrity": "sha512-XDIHEE6SU8VCF+dUVntD6PDv6RK31N0forx9kucZBYirbe8vCZ+Yx8hYgvtIaGrTcWtGxibxmND0pIuHDq8H5g==",
       "cpu": [
         "x64"
       ],
@@ -1405,9 +1408,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.1.tgz",
-      "integrity": "sha512-xoEWQQ71waWc4BZcOjmatuvPUXKTv6MbIFzpm4LFeCHsg2iwai0ILmNXf81rJR+L1Wb9ifEke2sQpZSPNz1Iyg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.0.1.tgz",
+      "integrity": "sha512-yxIOuuz5EOx0F1FDtsyzaLgnDym0Ysxv8CWeJyDTKKmt9BVyITg6q/cD+RP9bEkT1TQi+PYXIMATSz675Q82xw==",
       "cpu": [
         "x64"
       ],
@@ -1420,9 +1423,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.1.tgz",
-      "integrity": "sha512-hswVFYQYIeGHE2JYaBVtvqmBQ1CppplQbZJS/JgrVI3x2CurNhEkmds/yqvDONfwfbttTtH4+q9Dzf/WVl3Opw==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.0.1.tgz",
+      "integrity": "sha512-+ucLe2qgQzP+FM94jD4ns6LDGyMFaX9k3lVHqu/tsQCy2giMymbport4y4p77mYcXEMlDaHMzlHgOQyHRniWFA==",
       "cpu": [
         "arm64"
       ],
@@ -1435,9 +1438,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.1.tgz",
-      "integrity": "sha512-Kny5JBehkTbKPmqulr5i+iKntO5YMP+bVM8Hf8UAmjSMVo3wehyLVc9IZkNmcbxi+vwETnQvJaT5ynYBkJ9dWA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.0.1.tgz",
+      "integrity": "sha512-Krr/qGN7OB35oZuvMAZKoXDt2IapynIWLh5A5rz6AODb7f/ZJqyAuZSK12vOa2zKdobS36Qm4IlxxBqn9c00MA==",
       "cpu": [
         "ia32"
       ],
@@ -1450,9 +1453,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.1.tgz",
-      "integrity": "sha512-W1ijvzzg+kPEX6LAc+50EYYSEo0FVu7dmTE+t+DM4iOLqgGHoW9uYSz9wCVdkXOEEMP9xhXfGpcSxsfDucyPkA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.0.1.tgz",
+      "integrity": "sha512-t/0G33t/6VGWZUGCOT7rG42qqvf/x+MrFp1CU+8CN6PrjSSL57R5bqkXfubV9t4eCEnUxVP+5Hn3MoEXEebtEw==",
       "cpu": [
         "x64"
       ],
@@ -2763,6 +2766,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -3542,11 +3550,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "12.3.1",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.0.1.tgz",
+      "integrity": "sha512-/N9UpSwkbEMj5pIiB235p7QHaSW08ta/iKVaIHF44wufxr+PuJVLwg5LzlAaQbmCZCBpYvVttl3ZxTusP1g2sg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "12.3.1",
+        "@next/eslint-plugin-next": "13.0.1",
         "@rushstack/eslint-patch": "^1.1.3",
         "@typescript-eslint/parser": "^5.21.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -7031,42 +7040,43 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "12.3.1",
-      "license": "MIT",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.0.1.tgz",
+      "integrity": "sha512-ErCNBPIeZMKFn6hX+ZBSlqZVgJIeitEqhGTuQUNmYXJ07/A71DZ7AJI8eyHYUdBb686LUpV1/oBdTq9RpzRVPg==",
       "dependencies": {
-        "@next/env": "12.3.1",
+        "@next/env": "13.0.1",
         "@swc/helpers": "0.4.11",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
-        "styled-jsx": "5.0.7",
+        "styled-jsx": "5.1.0",
         "use-sync-external-store": "1.2.0"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=12.22.0"
+        "node": ">=14.6.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "12.3.1",
-        "@next/swc-android-arm64": "12.3.1",
-        "@next/swc-darwin-arm64": "12.3.1",
-        "@next/swc-darwin-x64": "12.3.1",
-        "@next/swc-freebsd-x64": "12.3.1",
-        "@next/swc-linux-arm-gnueabihf": "12.3.1",
-        "@next/swc-linux-arm64-gnu": "12.3.1",
-        "@next/swc-linux-arm64-musl": "12.3.1",
-        "@next/swc-linux-x64-gnu": "12.3.1",
-        "@next/swc-linux-x64-musl": "12.3.1",
-        "@next/swc-win32-arm64-msvc": "12.3.1",
-        "@next/swc-win32-ia32-msvc": "12.3.1",
-        "@next/swc-win32-x64-msvc": "12.3.1"
+        "@next/swc-android-arm-eabi": "13.0.1",
+        "@next/swc-android-arm64": "13.0.1",
+        "@next/swc-darwin-arm64": "13.0.1",
+        "@next/swc-darwin-x64": "13.0.1",
+        "@next/swc-freebsd-x64": "13.0.1",
+        "@next/swc-linux-arm-gnueabihf": "13.0.1",
+        "@next/swc-linux-arm64-gnu": "13.0.1",
+        "@next/swc-linux-arm64-musl": "13.0.1",
+        "@next/swc-linux-x64-gnu": "13.0.1",
+        "@next/swc-linux-x64-musl": "13.0.1",
+        "@next/swc-win32-arm64-msvc": "13.0.1",
+        "@next/swc-win32-ia32-msvc": "13.0.1",
+        "@next/swc-win32-x64-msvc": "13.0.1"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
         "node-sass": "^6.0.0 || ^7.0.0",
-        "react": "^17.0.2 || ^18.0.0-0",
-        "react-dom": "^17.0.2 || ^18.0.0-0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
@@ -8994,8 +9004,12 @@
       "license": "ISC"
     },
     "node_modules/styled-jsx": {
-      "version": "5.0.7",
-      "license": "MIT",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.0.tgz",
+      "integrity": "sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10849,35 +10863,95 @@
       }
     },
     "@next/env": {
-      "version": "12.3.1"
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.0.1.tgz",
+      "integrity": "sha512-gK60YoFae3s8qi5UgIzbvxOhsh5gKyEaiKH5+kLBUYXLlrPyWJR2xKBj2WqvHkO7wDX7/Hed3DAqjSpU4ijIvQ=="
     },
     "@next/eslint-plugin-next": {
-      "version": "12.3.1",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.0.1.tgz",
+      "integrity": "sha512-t3bggJhKE/oB4pvMM7hMNnmIpIqsMGJ+OLklk8llOkSeXtfCV+MBQbhImWxf5QODkxNAmMK3IJGAAecQhBTc/Q==",
       "dev": true,
       "requires": {
         "glob": "7.1.7"
       }
     },
     "@next/swc-android-arm-eabi": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.1.tgz",
-      "integrity": "sha512-i+BvKA8tB//srVPPQxIQN5lvfROcfv4OB23/L1nXznP+N/TyKL8lql3l7oo2LNhnH66zWhfoemg3Q4VJZSruzQ==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.1.tgz",
+      "integrity": "sha512-M28QSbohZlNXNn//HY6lV2T3YaMzG58Jwr0YwOdVmOQv6i+7lu6xe3GqQu4kdqInqhLrBXnL+nabFuGTVSHtTg==",
       "optional": true
     },
     "@next/swc-android-arm64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.1.tgz",
-      "integrity": "sha512-CmgU2ZNyBP0rkugOOqLnjl3+eRpXBzB/I2sjwcGZ7/Z6RcUJXK5Evz+N0ucOxqE4cZ3gkTeXtSzRrMK2mGYV8Q==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.0.1.tgz",
+      "integrity": "sha512-szmO/i6GoHcPXcbhUKhwBMETWHNXH3ITz9wfxwOOFBNKdDU8pjKsHL88lg28aOiQYZSU1sxu1v1p9KY5kJIZCg==",
       "optional": true
     },
     "@next/swc-darwin-arm64": {
-      "version": "12.3.1",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.0.1.tgz",
+      "integrity": "sha512-O1RxCaiDNOjGZmdAp6SQoHUITt9aVDQXoR3lZ/TloI/NKRAyAV4u0KUUofK+KaZeHOmVTnPUaQuCyZSc3i1x5Q==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.1.tgz",
-      "integrity": "sha512-9S6EVueCVCyGf2vuiLiGEHZCJcPAxglyckTZcEwLdJwozLqN0gtS0Eq0bQlGS3dH49Py/rQYpZ3KVWZ9BUf/WA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.0.1.tgz",
+      "integrity": "sha512-8E6BY/VO+QqQkthhoWgB8mJMw1NcN9Vhl2OwEwxv8jy2r3zjeU+WNRxz4y8RLbcY0R1h+vHlXuP0mLnuac84tQ==",
+      "optional": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.0.1.tgz",
+      "integrity": "sha512-ocwoOxm2KVwF50RyoAT+2RQPLlkyoF7sAqzMUVgj+S6+DTkY3iwH+Zpo0XAk2pnqT9qguOrKnEpq9EIx//+K7Q==",
+      "optional": true
+    },
+    "@next/swc-linux-arm-gnueabihf": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.0.1.tgz",
+      "integrity": "sha512-yO7e3zITfGol/N6lPQnmIRi0WyuILBMXrvH6EdmWzzqMDJFfTCII6l+B6gMO5WVDCTQUGQlQRNZ7sFqWR4I71g==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-gnu": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.0.1.tgz",
+      "integrity": "sha512-OEs6WDPDI8RyM8SjOqTDMqMBfOlU97VnW6ZMXUvzUTyH0K9c7NF+cn7UMu+I4tKFN0uJ9WQs/6TYaFBGkgoVVA==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-musl": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.0.1.tgz",
+      "integrity": "sha512-y5ypFK0Y3urZSFoQxbtDqvKsBx026sz+Fm+xHlPWlGHNZrbs3Q812iONjcZTo09QwRMk5X86iMWBRxV18xMhaw==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-gnu": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.0.1.tgz",
+      "integrity": "sha512-XDIHEE6SU8VCF+dUVntD6PDv6RK31N0forx9kucZBYirbe8vCZ+Yx8hYgvtIaGrTcWtGxibxmND0pIuHDq8H5g==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-musl": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.0.1.tgz",
+      "integrity": "sha512-yxIOuuz5EOx0F1FDtsyzaLgnDym0Ysxv8CWeJyDTKKmt9BVyITg6q/cD+RP9bEkT1TQi+PYXIMATSz675Q82xw==",
+      "optional": true
+    },
+    "@next/swc-win32-arm64-msvc": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.0.1.tgz",
+      "integrity": "sha512-+ucLe2qgQzP+FM94jD4ns6LDGyMFaX9k3lVHqu/tsQCy2giMymbport4y4p77mYcXEMlDaHMzlHgOQyHRniWFA==",
+      "optional": true
+    },
+    "@next/swc-win32-ia32-msvc": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.0.1.tgz",
+      "integrity": "sha512-Krr/qGN7OB35oZuvMAZKoXDt2IapynIWLh5A5rz6AODb7f/ZJqyAuZSK12vOa2zKdobS36Qm4IlxxBqn9c00MA==",
+      "optional": true
+    },
+    "@next/swc-win32-x64-msvc": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.0.1.tgz",
+      "integrity": "sha512-t/0G33t/6VGWZUGCOT7rG42qqvf/x+MrFp1CU+8CN6PrjSSL57R5bqkXfubV9t4eCEnUxVP+5Hn3MoEXEebtEw==",
       "optional": true
     },
     "@next/swc-freebsd-x64": {
@@ -11826,6 +11900,11 @@
         "string-width": "^5.0.0"
       }
     },
+    "client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
     "cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -12376,10 +12455,12 @@
       }
     },
     "eslint-config-next": {
-      "version": "12.3.1",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.0.1.tgz",
+      "integrity": "sha512-/N9UpSwkbEMj5pIiB235p7QHaSW08ta/iKVaIHF44wufxr+PuJVLwg5LzlAaQbmCZCBpYvVttl3ZxTusP1g2sg==",
       "dev": true,
       "requires": {
-        "@next/eslint-plugin-next": "12.3.1",
+        "@next/eslint-plugin-next": "13.0.1",
         "@rushstack/eslint-patch": "^1.1.3",
         "@typescript-eslint/parser": "^5.21.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -14734,26 +14815,28 @@
       "dev": true
     },
     "next": {
-      "version": "12.3.1",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.0.1.tgz",
+      "integrity": "sha512-ErCNBPIeZMKFn6hX+ZBSlqZVgJIeitEqhGTuQUNmYXJ07/A71DZ7AJI8eyHYUdBb686LUpV1/oBdTq9RpzRVPg==",
       "requires": {
-        "@next/env": "12.3.1",
-        "@next/swc-android-arm-eabi": "12.3.1",
-        "@next/swc-android-arm64": "12.3.1",
-        "@next/swc-darwin-arm64": "12.3.1",
-        "@next/swc-darwin-x64": "12.3.1",
-        "@next/swc-freebsd-x64": "12.3.1",
-        "@next/swc-linux-arm-gnueabihf": "12.3.1",
-        "@next/swc-linux-arm64-gnu": "12.3.1",
-        "@next/swc-linux-arm64-musl": "12.3.1",
-        "@next/swc-linux-x64-gnu": "12.3.1",
-        "@next/swc-linux-x64-musl": "12.3.1",
-        "@next/swc-win32-arm64-msvc": "12.3.1",
-        "@next/swc-win32-ia32-msvc": "12.3.1",
-        "@next/swc-win32-x64-msvc": "12.3.1",
+        "@next/env": "13.0.1",
+        "@next/swc-android-arm-eabi": "13.0.1",
+        "@next/swc-android-arm64": "13.0.1",
+        "@next/swc-darwin-arm64": "13.0.1",
+        "@next/swc-darwin-x64": "13.0.1",
+        "@next/swc-freebsd-x64": "13.0.1",
+        "@next/swc-linux-arm-gnueabihf": "13.0.1",
+        "@next/swc-linux-arm64-gnu": "13.0.1",
+        "@next/swc-linux-arm64-musl": "13.0.1",
+        "@next/swc-linux-x64-gnu": "13.0.1",
+        "@next/swc-linux-x64-musl": "13.0.1",
+        "@next/swc-win32-arm64-msvc": "13.0.1",
+        "@next/swc-win32-ia32-msvc": "13.0.1",
+        "@next/swc-win32-x64-msvc": "13.0.1",
         "@swc/helpers": "0.4.11",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
-        "styled-jsx": "5.0.7",
+        "styled-jsx": "5.1.0",
         "use-sync-external-store": "1.2.0"
       }
     },
@@ -15964,8 +16047,12 @@
       "dev": true
     },
     "styled-jsx": {
-      "version": "5.0.7",
-      "requires": {}
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.0.tgz",
+      "integrity": "sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==",
+      "requires": {
+        "client-only": "0.0.1"
+      }
     },
     "stylelint": {
       "version": "14.14.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "check-node-version": "^4.2.1",
     "isomorphic-dompurify": "^0.23.0",
     "marked": "^4.1.1",
-    "next": "12.3.1",
+    "next": "^13.0.1",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
@@ -33,7 +33,7 @@
     "check-node-version": "^4.2.1",
     "eslint": "8.26.0",
     "eslint-config-airbnb": "^19.0.4",
-    "eslint-config-next": "12.3.1",
+    "eslint-config-next": "^13.0.1",
     "husky": "^8.0.1",
     "jest": "^29.2.2",
     "jest-environment-jsdom": "^29.2.2",

--- a/src/components/ComponentCard.jsx
+++ b/src/components/ComponentCard.jsx
@@ -2,13 +2,11 @@ import Link from 'next/link';
 
 export default function ComponentCard({ name, slug, image }) {
   return (
-    <Link href={slug}>
-      <a className="component-link">
-        <div className="component-card">
-          <span className="component-card__header">{name}</span>
-          <img src={image} alt="" className="component-card__image" />
-        </div>
-      </a>
+    <Link href={slug} className="component-link">
+      <div className="component-card">
+        <span className="component-card__header">{name}</span>
+        <img src={image} alt="" className="component-card__image" />
+      </div>
     </Link>
   );
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,13 +4,11 @@ export default function Header() {
   return (
     <header className="cmp-header" data-testid="header">
       <Link href="/" aria-label="To home page" className="cmp-header__link">
-        <a>
-          <img
-            className="cmp-header__logo"
-            src="/sparkbox-logo-text.svg"
-            alt="Sparkbox logo"
-          />
-        </a>
+        <img
+          className="cmp-header__logo"
+          src="/sparkbox-logo-text.svg"
+          alt="Sparkbox logo"
+        />
       </Link>
     </header>
   );

--- a/src/pages/404.page.jsx
+++ b/src/pages/404.page.jsx
@@ -5,20 +5,7 @@ export default function ErrorPage() {
   return (
     <Layout pageTitle="404">
       <h1>404 Not Found</h1>
-      <Link href="/"><a>Overview Page</a></Link>
+      <Link href="/">Overview Page</Link>
     </Layout>
   );
 }
-
-// THE CODE BELOW WAS INCLUDED IN THE ORIGINAL 404.JSX FILE. IT MAY HAVE BEEN OVERWRITTEN ON
-// ACCIDENT SO I'M KEEPING IT HERE JUST IN CASE WE NEED IT AGAIN.
-// export default function ErrorPage() {
-//   return (
-//     <div>
-//       {/* <PageTitle title="404 Not Found" /> */}
-//       {/* <Header /> */}
-//       <h1>404 Not Found</h1>
-//       <Link href="/"><a>Overview Page</a></Link>
-//     </div>
-//   );
-// }

--- a/src/styles/components/_definition.scss
+++ b/src/styles/components/_definition.scss
@@ -1,6 +1,8 @@
 $breakpoint-tablet: 820px;
 
 .cmp-definition {
+  min-height: 20rem;
+
   &__heading {
     position: relative;
     font-family: Viga, sans-serif;


### PR DESCRIPTION
### Description:

This PR should update NextJs and `eslint-config-next` to version 13. In Next13 we don't need to have `<a>` tags inside Links anymore, so we can remove them.

### Spec:

See Story: [FSA22V2-279](https://sparkbox.atlassian.net/jira/software/c/projects/FSA22V2/boards/125?modal=detail&selectedIssue=FSA22V2-279)

### Validation:

- [x] This PR has code changes, and our linters still pass.
- [x] This PR has new code, so new tests were added or updated, and they pass.

#### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
3. Run `npm install` to make sure you have all proper dependencies. (this project requires Node 16+)
4. Copy the `.env.example` file, making sure it's in the root of your project, and rename it `.env.local`. Search for "Accessible Components" in 1Password to find the API Key and Base ID. Add both of those secrets to your newly created `.env.local` file. That should establish your connection to our Airtable database.
5. Run `npm run lint` to confirm no errors.
6. Run `npm run test` to confirm all tests pass.
7. In terminal: `npm run dev`.
8. Check [localhost:3000](http://localhost:3000/) to see changes.
9. Run axe Devtools on affected pages to confirm no urgent errors.