### PR TITLE
Fsa22 v2 284 refactor rename breakpoint sass variables

### DIFF
--- a/src/styles/components/_code-block.scss
+++ b/src/styles/components/_code-block.scss
@@ -1,4 +1,6 @@
-$breakpoint-tablet: 820px;
+$breakpoint-increase-content-font-size: $breakpoint-scale-up;
+$breakpoint-increase-codeblock-font: $breakpoint-scale-up;
+$breakpoint-increase-padding: $breakpoint-scale-up;
 
 .cmp-code-block {
   width: 100%;
@@ -28,7 +30,7 @@ $breakpoint-tablet: 820px;
       }
     }
 
-    @media only screen and (min-width: $breakpoint-tablet) {
+    @media only screen and (min-width: $breakpoint-increase-content-font-size) {
       font-size: map.get($font-sizes, "md");
       line-height: 2.5rem; // 40px/16
 
@@ -50,7 +52,7 @@ $breakpoint-tablet: 820px;
     margin-top: 1rem;
     border: 2px solid var(--foreground-color);
 
-    @media only screen and (min-width: $breakpoint-tablet) {
+    @media (min-width: $breakpoint-scale-up) {
       padding: 2.5rem 3.75rem; // top&bottom: 40px/16; left&right: 60px/16
       margin: 0;
     }
@@ -74,7 +76,7 @@ $breakpoint-tablet: 820px;
     letter-spacing: 0.02em; // 2% in Figma
     font-family: Oxygen, sans-serif;
 
-    @media only screen and (min-width: $breakpoint-tablet) {
+    @media (min-width: $breakpoint-increase-codeblock-font) {
       font-size: map.get($font-sizes, "sm");
     }
   }

--- a/src/styles/components/_component-card.scss
+++ b/src/styles/components/_component-card.scss
@@ -1,3 +1,7 @@
+$breakpoint-illustration-small: 30rem;
+$breakpoint-illustration-medium: 43rem;
+$breakpoint-illustration-large: $breakpoint-large-screen-860;
+
 .component-link {
   display: block;
   outline: none;
@@ -25,15 +29,15 @@
     }
 
     // the following breakpoints are where certain illustrations try to break out of their containers
-    @media only screen and (min-width: 475px) {
+    @media (min-width: $breakpoint-illustration-small) {
       height: 30rem; // 480px/16px
     }
 
-    @media only screen and (min-width: 690px) {
+    @media (min-width: $breakpoint-illustration-medium) {
       height: 40rem; // 640px/16px
     }
 
-    @media only screen and (min-width: $breakpoint-tablet) {
+    @media (min-width: $breakpoint-illustration-large) {
       height: 100%;
     }
 
@@ -62,7 +66,7 @@
         border-top: 0.25rem solid var(--background-color);
       }
 
-      @media only screen and (min-width: $breakpoint-tablet) {
+      @media only screen and (min-width: $breakpoint-scale-up) {
         font-size: map.get($font-sizes, "sm"); // 20px/16
       }
 

--- a/src/styles/components/_component-grid.scss
+++ b/src/styles/components/_component-grid.scss
@@ -1,4 +1,14 @@
-$breakpoint-tablet: 820px;
+$breakpoint-accordion-small-355: 22rem;
+$breakpoint-accordion-small-390: 24rem;
+$breakpoint-accordion-small-420: 26rem;
+$breakpoint-accordion-small-460: 29rem;
+$breakpoint-accordion-small-475: 30rem;
+$breakpoint-accordion-medium-550: 34rem;
+$breakpoint-accordion-medium-580: 36rem;
+$breakpoint-accordion-medium-620: 39rem;
+$breakpoint-accordion-medium-665: 42rem;
+$breakpoint-accordion-medium-690: 43rem;
+$breakpoint-accordion-large-755: 47rem;
 
 // grid section
 .components-grid {
@@ -6,7 +16,7 @@ $breakpoint-tablet: 820px;
   max-width: 100rem; // 1600px/16
   place-items: center;
 
-  @media only screen and (min-width: 100rem) {
+  @media (min-width: 100rem) {
     margin-inline: auto;
   }
 
@@ -59,67 +69,67 @@ $breakpoint-tablet: 820px;
       }
 
       // the following breakpoints are where the accordion illustration starts breaking out of the container
-      @media only screen and (min-width: 355px) {
+      @media (min-width: $breakpoint-accordion-small-355) {
         img {
           bottom: -9rem;
         }
       }
 
-      @media only screen and (min-width: 390px) {
+      @media (min-width: $breakpoint-accordion-small-390) {
         img {
           bottom: -12rem;
         }
       }
 
-      @media only screen and (min-width: 420px) {
+      @media (min-width: $breakpoint-accordion-small-420) {
         img {
           bottom: -15rem;
         }
       }
 
-      @media only screen and (min-width: 460px) {
+      @media (min-width: $breakpoint-accordion-small-460) {
         img {
           bottom: -18rem;
         }
       }
 
-      @media only screen and (min-width: 475px) {
+      @media (min-width: $breakpoint-accordion-small-475) {
         img {
           bottom: -15rem;
         }
       }
 
-      @media only screen and (min-width: 550px) {
+      @media (min-width: $breakpoint-accordion-medium-550) {
         img {
           bottom: -18rem;
         }
       }
 
-      @media only screen and (min-width: 580px) {
+      @media (min-width: $breakpoint-accordion-medium-580) {
         img {
           bottom: -21rem;
         }
       }
 
-      @media only screen and (min-width: 620px) {
+      @media only screen and (min-width: $breakpoint-accordion-medium-620) {
         img {
           bottom: -25rem;
         }
       }
 
-      @media only screen and (min-width: 665px) {
+      @media only screen and (min-width: $breakpoint-accordion-medium-665) {
         img {
           bottom: -28rem;
         }
       }
 
-      @media only screen and (min-width: 690px) {
+      @media only screen and (min-width: $breakpoint-accordion-medium-690) {
         img {
           bottom: -23rem;
         }
       }
 
-      @media only screen and (min-width: 755px) {
+      @media (min-width: $breakpoint-accordion-large-755) {
         img {
           bottom: -28rem;
         }
@@ -264,7 +274,7 @@ $breakpoint-tablet: 820px;
     }
   }
 
-  @media only screen and (min-width: $breakpoint-tablet) {
+  @media (min-width: $breakpoint-grid-large-screen-1115) {
     // grid section
     padding: 5rem 8.5625rem; // top&bottom: 80px/16; left&right: 137px/16
 

--- a/src/styles/components/_definition.scss
+++ b/src/styles/components/_definition.scss
@@ -1,4 +1,4 @@
-$breakpoint-tablet: 820px;
+$breakpoint-background-image-size: 75rem;
 
 .cmp-definition {
   position: relative;
@@ -40,7 +40,7 @@ $breakpoint-tablet: 820px;
     letter-spacing: 0.02rem;
   }
 
-  @media only screen and (min-width: $breakpoint-tablet) {
+  @media (min-width: $breakpoint-large-screen-860) {
     &__bg-text {
       position: absolute;
       top: 0;
@@ -56,7 +56,7 @@ $breakpoint-tablet: 820px;
       margin: auto;
       z-index: -1;
 
-      @media only screen and (max-width: 75rem) {
+      @media (max-width: $breakpoint-background-image-size) {
         background-size: cover;
       }
 

--- a/src/styles/components/_detailsBanner.scss
+++ b/src/styles/components/_detailsBanner.scss
@@ -1,5 +1,3 @@
-$breakpoint-tablet: 820px;
-
 .details-banner {
   // background-image: url("../../../public/images/background_image.svg");
   background-position: center;
@@ -15,7 +13,7 @@ $breakpoint-tablet: 820px;
     font-family: Viga, sans-serif;
     font-size: 1.5625rem; // 25px/16
 
-    @media only screen and (min-width: $breakpoint-tablet) {
+    @media (min-width: $breakpoint-scale-up) {
       font-size: map.get($font-sizes, "xl");
       line-height: 4.1875rem; // 67px/16
       margin: 2.5rem 0; // top&bottom: 40px/16; left&right: 0
@@ -38,7 +36,7 @@ $breakpoint-tablet: 820px;
   }
 }
 
-@media only screen and (min-width: $breakpoint-tablet) {
+@media (min-width: $breakpoint-large-screen-860) {
   .details-banner {
     h1 {
       font-size: 3.125rem;

--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -1,3 +1,5 @@
+$breakpoint-footer-margin: 25em;
+
 .default-footer {
   background-color: var(--background-color);
   width: 100%;
@@ -21,7 +23,7 @@
     transition: 500ms color;
     letter-spacing: 0.02em; // 2% in Figma
 
-    @media only screen and (min-width: $breakpoint-tablet) {
+    @media (min-width: $breakpoint-large-screen-860) {
       line-height: 1.0625rem; /* 17px/16px */
       font-size: 1.25rem; /* 20px/16px */
     }
@@ -38,7 +40,7 @@
       margin-bottom: -1.875rem; // 30px/16
     }
 
-    @media only screen and (min-width: $breakpoint-tablet) {
+    @media (min-width: $breakpoint-large-screen-860) {
       &:first-child {
         margin-bottom: -43px; // this is to compensate for the 17px line-height once at tablet size
       }
@@ -55,7 +57,7 @@
     transition: ease-in-out all 250ms;
     outline: none;
 
-    @media screen and (prefers-reduced-motion: no-preference) {
+    @media (prefers-reduced-motion: no-preference) {
       &:hover,
       &:focus-within {
         color: var(--font-color-dark);
@@ -63,7 +65,7 @@
       }
     }
 
-    @media screen and (prefers-reduced-motion: reduce) {
+    @media (prefers-reduced-motion: reduce) {
       &:hover,
       &:focus-within {
         color: var(--font-color-dark);
@@ -91,7 +93,7 @@
       right: 0;
     }
 
-    @media only screen and (min-width: 400px) {
+    @media (min-width: $breakpoint-footer-margin) {
       margin: auto;
     }
 

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -1,5 +1,3 @@
-$breakpoint-tablet: 820px;
-
 // sparkbox header
 .cmp-header {
   padding: 1rem; // 16px
@@ -24,11 +22,11 @@ $breakpoint-tablet: 820px;
     }
   }
 
-  @media only screen and (min-width: $breakpoint-tablet) {
+  @media (min-width: $breakpoint-large-screen-860) {
     padding: 1rem 1.25rem 0 8.5625rem; // top: 16px/16; right: 20px/16; bottom: 0; left: 137px/16
   }
 
-  @media only screen and (min-width: 100rem) {
+  @media (min-width: 100rem) {
     margin: auto;
   }
 }

--- a/src/styles/components/_home.scss
+++ b/src/styles/components/_home.scss
@@ -1,6 +1,7 @@
-// listing/home page
-$breakpoint-tablet: 820px;
+$breakpoint-top-section-margin: 70rem;
+$breakpoint-top-section-scale-up: 70rem;
 
+// listing/home page
 // everything below the SB logo & above the footer
 .home {
   @include background-pattern;
@@ -18,7 +19,7 @@ $breakpoint-tablet: 820px;
     color: var(--foreground-color);
     max-width: 100rem; // 1600px/16
 
-    @media only screen and (min-width: 100rem) {
+    @media (min-width: $breakpoint-top-section-margin) {
       margin: auto;
     }
   }
@@ -43,10 +44,17 @@ $breakpoint-tablet: 820px;
     margin: 3.75rem 0; // top&bottom: 60px/16; left&right: 0
   }
 
-  // the tablet breakpoint does leave some issues with the hero section
+  &__date-updated {
+    font-family: Oxygen, sans-serif;
+    font-size: map.get($font-sizes, "xs");
+    text-align: center;
+    line-height: 1.75rem; // 28px/16
+    letter-spacing: 0.02em; // 2% in Figma
+  }
+
   // these styles are NOT in the design, but are here to just fix up the
   // visual experience for tablets
-  @media only screen and (min-width: $breakpoint-tablet) {
+  @media (min-width: $breakpoint-large-screen-860) {
     &-top {
       padding: 0 1.25rem 1.25rem 8.5625rem; // top&bottom: 0; right: 20px/16; left: 137px/16
       display: flex;
@@ -74,7 +82,7 @@ $breakpoint-tablet: 820px;
   }
 
   // this is where the font styles in the designs are officially applied
-  @media only screen and (min-width: 1115px) {
+  @media (min-width: $breakpoint-top-section-scale-up) {
     &-top {
       h1 {
         font-size: map.get($font-sizes, "xl");

--- a/src/styles/components/_related-components.scss
+++ b/src/styles/components/_related-components.scss
@@ -1,5 +1,3 @@
-$breakpoint-tablet: 820px;
-
 .rel-component {
   background-color: var(--accent-color);
   color: var(--font-color-highlight);
@@ -34,7 +32,7 @@ $breakpoint-tablet: 820px;
       }
     }
 
-    @media only screen and (min-width: $breakpoint-tablet) {
+    @media (min-width: $breakpoint-scale-up) {
       &::after {
         right: 6rem;
         top: -3.25rem;
@@ -77,7 +75,7 @@ $breakpoint-tablet: 820px;
     }
   }
 
-  @media only screen and (min-width: $breakpoint-tablet) {
+  @media (min-width: $breakpoint-large-screen-860) {
     flex-direction: row;
     gap: 15%;
 

--- a/src/styles/components/_specification-block.scss
+++ b/src/styles/components/_specification-block.scss
@@ -1,5 +1,3 @@
-$breakpoint-tablet: 1150px;
-
 .cmp-specifications-block {
   display: flex;
   flex-direction: column;
@@ -91,7 +89,7 @@ $breakpoint-tablet: 1150px;
   }
 
   // matches the related components text-links
-  @media screen and (prefers-reduced-motion: reduce) {
+  @media (prefers-reduced-motion: reduce) {
     a {
       transition: all ease-in-out 100ms;
 
@@ -103,7 +101,7 @@ $breakpoint-tablet: 1150px;
     }
   }
 
-  @media only screen and (min-width: $breakpoint-tablet) {
+  @media (min-width: $breakpoint-grid-large-screen-1115) {
     // grid of data fields & content (.cmp-specifications-block)
     display: grid;
     column-gap: 5rem; // 80px /16

--- a/src/styles/components/_usage-guidelines.scss
+++ b/src/styles/components/_usage-guidelines.scss
@@ -1,4 +1,4 @@
-$breakpoint-tablet: 860px;
+$breakpoint-usage-guidelines-display: 70rem;
 
 .cmp-usage-guidelines {
   display: flex;
@@ -55,7 +55,7 @@ $breakpoint-tablet: 860px;
   }
 }
 
-@media only screen and (min-width: $breakpoint-tablet) {
+@media (min-width: $breakpoint-usage-guidelines-display) {
   .cmp-usage-guidelines {
     background-color: var(--accent-color-background);
     width: 100%;

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -2,6 +2,7 @@
 @use "sass:map";
 @import "./settings/colors";
 @import "./settings/font_map";
+@import "./settings/breakpoints";
 
 /* TOOLS: mixins, etc */
 @import "./tools/mixins";

--- a/src/styles/settings/_breakpoints.scss
+++ b/src/styles/settings/_breakpoints.scss
@@ -1,0 +1,3 @@
+$breakpoint-large-screen-860: 54rem;
+$breakpoint-grid-large-screen-1115: 72rem;
+$breakpoint-scale-up: 51rem;


### PR DESCRIPTION
### Description:

Sass breakpoint variables are updated throughout the code base to use descriptive names rather than device-type names.

### Spec:

Designs: [Designs](DESIGN_URL)

See Story: [FSA22V2-284](https://sparkbox.atlassian.net/browse/FSA22V2-284)

### Validation:

<!-- Add description of work done here -->

- [ ] This PR has code changes, and our linters still pass.
- [ ] This PR affects production code, so it was browser tested (see below).
- [ ] This PR has new code, so new tests were added or updated, and they pass.

#### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
3. Run `npm install` to make sure you have all proper dependencies. (this project requires Node 16+)
4. Copy the `.env.example` file, making sure it's in the root of your project, and rename it `.env.local`. Search for "Accessible Components" in 1Password to find the API Key and Base ID. Add both of those secrets to your newly created `.env.local` file. That should establish your connection to our Airtable database.
5. Run `npm run lint` to confirm no errors.
6. Run `npm run test` to confirm all tests pass.
7. In terminal: `npm run dev`.
8. Check [localhost:3000](http://localhost:3000/) to see changes.
9. Run axe Devtools on affected pages to confirm no urgent errors.

In the styles scss files, check that any breakpoint names make sense in context of what they are accomplishing for the display.

### Pending Questions:

1.
2.

---

#### Browser Testing

<!--
The browser list should be tailored to specific engagement and client needs.
Delete if irrelevant to this issue
-->

In these browsers, behavior & design closely match original specifications. A user is able to access all content and functionality, including the usability of required assistive devices, such as keyboard and screenreader.

**macOS**

- [ ] Safari (last 2 major versions)
- [ ] Chrome (last 6 months)
- [ ] Firefox (last 6 months)

**Windows**

- [ ] Chrome (last 6 months)
- [ ] Firefox (last 6 months)
- [ ] Edge (last 6 months)

**Mobile**

- [ ] Safari (last 2 major versions)
- [ ] Chrome on Android (last 6 months)
- [ ] Firefox on Android (last 6 months)
