### PR TITLE
style: refactor SCSS queries

### DIFF
--- a/src/pages/[id].page.jsx
+++ b/src/pages/[id].page.jsx
@@ -57,7 +57,6 @@ export default function Details({ details }) {
         <CodeBlock name="HTML" exportedCodeString={htmlCode} />
         <CodeBlock name="CSS" exportedCodeString={cssCode} />
         <CodeBlock name="JS" exportedCodeString={javascriptCode} />
-
       </div>
       <div className="details-page__banner">
         <div className="details-page__secondary details-page__secondary--usage-guidelines">

--- a/src/styles/components/_code-block.scss
+++ b/src/styles/components/_code-block.scss
@@ -30,7 +30,7 @@ $breakpoint-increase-padding: $breakpoint-scale-up;
       }
     }
 
-    @media only screen and (min-width: $breakpoint-increase-content-font-size) {
+    @media (min-width: $breakpoint-increase-content-font-size) {
       font-size: map.get($font-sizes, "md");
       line-height: 2.5rem; // 40px/16
 

--- a/src/styles/components/_component-card.scss
+++ b/src/styles/components/_component-card.scss
@@ -17,15 +17,15 @@ $breakpoint-illustration-large: $breakpoint-large-screen-860;
     transition: all 150ms ease-in-out;
     border: 2px solid var(--foreground-color);
 
-    @media (prefers-color-scheme: dark) {
-      border: 2px solid var(--background-color);
-    }
-
     img {
       transition: all 150ms ease-in-out;
       width: 100%;
       height: auto;
       margin: auto;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      border: 2px solid var(--background-color);
     }
 
     // the following breakpoints are where certain illustrations try to break out of their containers
@@ -62,11 +62,7 @@ $breakpoint-illustration-large: $breakpoint-large-screen-860;
         background-color: var(--foreground-color);
       }
 
-      @media (prefers-color-scheme: dark) {
-        border-top: 0.25rem solid var(--background-color);
-      }
-
-      @media only screen and (min-width: $breakpoint-scale-up) {
+      @media (min-width: $breakpoint-scale-up) {
         font-size: map.get($font-sizes, "sm"); // 20px/16
       }
 

--- a/src/styles/components/_component-grid.scss
+++ b/src/styles/components/_component-grid.scss
@@ -16,6 +16,10 @@ $breakpoint-accordion-large-755: 47rem;
   max-width: 100rem; // 1600px/16
   place-items: center;
 
+  @media (min-width: $breakpoint-grid-large-screen-1115) {
+    padding: 5rem 8.5625rem; // top&bottom: 80px/16; left&right: 137px/16
+  }
+
   @media (min-width: 100rem) {
     margin-inline: auto;
   }
@@ -41,11 +45,29 @@ $breakpoint-accordion-large-755: 47rem;
       right: 4rem;
       background-position: 0;
     }
+
+    @media (min-width: $breakpoint-grid-large-screen-1115) {
+      font-size: map.get($font-sizes, "lg");
+
+      &::after {
+        display: none;
+      }
+    }
   }
 
   // grid list
   &__list {
     text-align: center;
+
+    @media (min-width: $breakpoint-grid-large-screen-1115) {
+      display: grid;
+      gap: 1rem;
+      list-style: none;
+      grid-template-areas:
+        "accordion dialog disclosure"
+        "accordion tabs tabs"
+        ". max-scott .";
+    }
   }
 
   // grid items/component cards
@@ -59,79 +81,71 @@ $breakpoint-accordion-large-755: 47rem;
     align-items: flex-start;
     color: var(--font-color-dark);
 
+    @media (min-width: $breakpoint-grid-large-screen-1115) {
+      margin-bottom: 0;
+    }
+
     &--accordion {
       grid-area: accordion;
       overflow: hidden;
 
+      @media (min-width: $breakpoint-grid-large-screen-1115) {
+        position: static;
+        overflow: visible;
+      }
+
       img {
         position: absolute;
         bottom: -6rem;
-      }
 
-      // the following breakpoints are where the accordion illustration starts breaking out of the container
-      @media (min-width: $breakpoint-accordion-small-355) {
-        img {
+        // the following breakpoints are where the accordion illustration starts breaking out of the container
+        @media (min-width: $breakpoint-accordion-small-355) {
           bottom: -9rem;
         }
-      }
 
-      @media (min-width: $breakpoint-accordion-small-390) {
-        img {
+        @media (min-width: $breakpoint-accordion-small-390) {
           bottom: -12rem;
         }
-      }
 
-      @media (min-width: $breakpoint-accordion-small-420) {
-        img {
+        @media (min-width: $breakpoint-accordion-small-420) {
           bottom: -15rem;
         }
-      }
 
-      @media (min-width: $breakpoint-accordion-small-460) {
-        img {
+        @media (min-width: $breakpoint-accordion-small-460) {
           bottom: -18rem;
         }
-      }
 
-      @media (min-width: $breakpoint-accordion-small-475) {
-        img {
+        @media (min-width: $breakpoint-accordion-small-475) {
           bottom: -15rem;
         }
-      }
 
-      @media (min-width: $breakpoint-accordion-medium-550) {
-        img {
+        @media (min-width: $breakpoint-accordion-medium-550) {
           bottom: -18rem;
         }
-      }
 
-      @media (min-width: $breakpoint-accordion-medium-580) {
-        img {
+        @media (min-width: $breakpoint-accordion-medium-580) {
           bottom: -21rem;
         }
-      }
 
-      @media only screen and (min-width: $breakpoint-accordion-medium-620) {
-        img {
+        @media only screen and (min-width: $breakpoint-accordion-medium-620) {
           bottom: -25rem;
         }
-      }
 
-      @media only screen and (min-width: $breakpoint-accordion-medium-665) {
-        img {
+        @media only screen and (min-width: $breakpoint-accordion-medium-665) {
           bottom: -28rem;
         }
-      }
 
-      @media only screen and (min-width: $breakpoint-accordion-medium-690) {
-        img {
+        @media only screen and (min-width: $breakpoint-accordion-medium-690) {
           bottom: -23rem;
         }
-      }
 
-      @media (min-width: $breakpoint-accordion-large-755) {
-        img {
+        @media (min-width: $breakpoint-accordion-large-755) {
           bottom: -28rem;
+        }
+
+        @media (min-width: $breakpoint-grid-large-screen-1115) {
+          position: static;
+          bottom: 0;
         }
       }
     }
@@ -151,7 +165,7 @@ $breakpoint-accordion-large-755: 47rem;
     &--max-scott {
       grid-area: max-scott;
       background-color: transparent;
-      max-width: 275px; // this closely matches the dimensions in Figma
+      max-width: 17.1875rem; // 275px/16
       height: auto;
       margin: auto;
     }
@@ -171,6 +185,10 @@ $breakpoint-accordion-large-755: 47rem;
         rotate: -10deg;
         background-size: contain;
         display: none;
+
+        @media (min-width: $breakpoint-grid-large-screen-1115) {
+          display: inline-block;
+        }
       }
     }
 
@@ -188,6 +206,10 @@ $breakpoint-accordion-large-755: 47rem;
         right: -6%;
         background-size: contain;
         display: none;
+
+        @media (min-width: $breakpoint-grid-large-screen-1115) {
+          display: inline-block;
+        }
       }
     }
 
@@ -206,6 +228,10 @@ $breakpoint-accordion-large-755: 47rem;
         top: -6%;
         right: -10%;
         display: none;
+
+        @media (min-width: $breakpoint-grid-large-screen-1115) {
+          display: inline-block;
+        }
       }
     }
 
@@ -223,6 +249,10 @@ $breakpoint-accordion-large-755: 47rem;
         top: -5%;
         left: -2%;
         display: none;
+
+        @media (min-width: $breakpoint-grid-large-screen-1115) {
+          display: inline-block;
+        }
       }
     }
 
@@ -240,6 +270,10 @@ $breakpoint-accordion-large-755: 47rem;
         bottom: -15%;
         left: -5%;
         display: none;
+
+        @media (min-width: $breakpoint-grid-large-screen-1115) {
+          display: inline-block;
+        }
       }
     }
 
@@ -257,6 +291,10 @@ $breakpoint-accordion-large-755: 47rem;
         display: inline-block;
         top: 0%;
         left: -15%;
+
+        @media (min-width: $breakpoint-grid-large-screen-1115) {
+          display: block;
+        }
       }
 
       &::after {
@@ -270,74 +308,6 @@ $breakpoint-accordion-large-755: 47rem;
         right: -28%;
         background-size: contain;
         background-position: 0;
-      }
-    }
-  }
-
-  @media (min-width: $breakpoint-grid-large-screen-1115) {
-    // grid section
-    padding: 5rem 8.5625rem; // top&bottom: 80px/16; left&right: 137px/16
-
-    &__heading {
-      font-size: map.get($font-sizes, "lg");
-
-      &::after {
-        display: none;
-      }
-    }
-
-    &__list {
-      display: grid;
-      gap: 1rem;
-      list-style: none;
-      grid-template-areas:
-        "accordion dialog disclosure"
-        "accordion tabs tabs"
-        ". max-scott .";
-    }
-
-    &__item {
-      margin-bottom: 0;
-
-      &--accordion {
-        grid-area: accordion;
-        position: static;
-        overflow: visible;
-
-        img {
-          position: static;
-          bottom: 0;
-        }
-      }
-
-      &--dialog {
-        grid-area: dialog;
-      }
-
-      &--disclosure {
-        grid-area: disclosure;
-      }
-
-      &--tabs {
-        grid-area: tabs;
-      }
-
-      &--max-scott {
-        grid-area: max-scott;
-        width: 77%;
-      }
-
-      // Show doodle
-      &:nth-child(n) {
-        &::before {
-          display: inline-block;
-        }
-      }
-
-      &:last-child {
-        &::before {
-          display: block;
-        }
       }
     }
   }

--- a/src/styles/components/_definition.scss
+++ b/src/styles/components/_definition.scss
@@ -5,6 +5,16 @@ $breakpoint-background-image-size: 75rem;
   line-height: 1.75rem;
   color: var(--foreground-color);
 
+  // the text column
+  &__text {
+    padding: 0;
+    max-width: 60ch;
+
+    @media (min-width: $breakpoint-large-screen-860) {
+      padding: 8rem 0;
+    }
+  }
+
   &__heading {
     position: relative;
     font-family: Viga, sans-serif;
@@ -28,18 +38,33 @@ $breakpoint-background-image-size: 75rem;
         filter: invert(1);
       }
     }
+
+    @media (min-width: $breakpoint-large-screen-860) {
+      font-size: map.get($font-sizes, "md");
+
+      &::after {
+        content: "";
+        top: -2.5rem;
+        left: -2.2rem;
+        width: 15rem;
+        height: 6rem;
+        background-size: 100%;
+      }
+    }
   }
 
-  &__text {
-    padding: 0;
-    max-width: 60ch;
-  }
-
+  // airtable paragraphs, not including the heading
   &__content {
     font-size: map.get($font-sizes, "xs");
     letter-spacing: 0.02rem;
+
+    @media (min-width: $breakpoint-large-screen-860) {
+      position: relative;
+      font-size: map.get($font-sizes, "sm");
+    }
   }
 
+  // show the background definition text
   @media (min-width: $breakpoint-large-screen-860) {
     &__bg-text {
       position: absolute;
@@ -56,10 +81,6 @@ $breakpoint-background-image-size: 75rem;
       margin: auto;
       z-index: -1;
 
-      @media (max-width: $breakpoint-background-image-size) {
-        background-size: cover;
-      }
-
       @media (prefers-color-scheme: dark) {
         right: -7rem;
         background: linear-gradient(to right, var(--background-color) 50%, transparent), url("../../../public/images/definition_text_dark.svg");
@@ -69,28 +90,6 @@ $breakpoint-background-image-size: 75rem;
         margin: auto;
         z-index: -1;
       }
-    }
-
-    &__heading {
-      font-size: map.get($font-sizes, "md");
-
-      &::after {
-        content: "";
-        top: -2.5rem;
-        left: -2.2rem;
-        width: 15rem;
-        height: 6rem;
-        background-size: 100%;
-      }
-    }
-
-    &__content {
-      position: relative;
-      font-size: map.get($font-sizes, "sm");
-    }
-
-    &__text {
-      padding: 8rem 0;
     }
   }
 }

--- a/src/styles/components/_details-page.scss
+++ b/src/styles/components/_details-page.scss
@@ -9,6 +9,11 @@
     @media (prefers-color-scheme: dark) {
       background-image: url("../../../public/images/background_image-light.svg");
     }
+
+    @media (min-width: $breakpoint-large-screen-860) {
+      padding: 5rem 8.5625rem;
+      gap: 1rem;
+    }
   }
 
   &__banner {
@@ -32,6 +37,11 @@
     padding: 3.75rem 1.25rem;
     max-width: 100rem; // 1600px;
     overflow: hidden;
+
+    @media (min-width: $breakpoint-scale-up) {
+      padding: 8.5625rem;
+      gap: 1rem;
+    }
   }
 
   &__secondary {
@@ -40,27 +50,15 @@
     margin: auto;
     padding: 3.75rem 1.25rem;
     max-width: 100rem;
-  }
 
-  @media (prefers-color-scheme: dark) {
-    &__secondary--usage-guidelines {
-      background-color: var(--accent-color-background);
-    }
-
-    &__secondary--related-components {
-      background-color: var(--background-color);
-    }
-  }
-
-  @media only screen and (min-width: $breakpoint-tablet) {
-    &__primary,
-    &__heading {
-      padding: 8.5625rem;
-      gap: 1rem;
-    }
-
-    &__secondary {
+    @media (min-width: $breakpoint-scale-up) {
       padding: 5.875rem;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      &--related-components {
+        background-color: var(--background-color);
+      }
     }
   }
 }

--- a/src/styles/components/_detailsBanner.scss
+++ b/src/styles/components/_detailsBanner.scss
@@ -1,10 +1,13 @@
 .details-banner {
-  // background-image: url("../../../public/images/background_image.svg");
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
   line-height: 2.125rem; // 28px
   letter-spacing: 0.02em; // 2% in Figma
+
+  @media (min-width: $breakpoint-large-screen-860) {
+    margin: -8.5625rem;
+  }
 
   h1 {
     margin: 1.875rem 0; // top&bottom: 30px/16; left&right: 0
@@ -13,7 +16,7 @@
     font-family: Viga, sans-serif;
     font-size: 1.5625rem; // 25px/16
 
-    @media (min-width: $breakpoint-scale-up) {
+    @media (min-width: $breakpoint-large-screen-860) {
       font-size: map.get($font-sizes, "xl");
       line-height: 4.1875rem; // 67px/16
       margin: 2.5rem 0; // top&bottom: 40px/16; left&right: 0
@@ -32,15 +35,6 @@
     img {
       width: 100%;
       max-height: 45rem;
-    }
-  }
-}
-
-@media (min-width: $breakpoint-large-screen-860) {
-  .details-banner {
-    h1 {
-      font-size: 3.125rem;
-      margin: 2.5rem 0;
     }
   }
 }

--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -38,10 +38,8 @@ $breakpoint-footer-margin: 25em;
     // this compensates for that
     &:first-child {
       margin-bottom: -1.875rem; // 30px/16
-    }
 
-    @media (min-width: $breakpoint-large-screen-860) {
-      &:first-child {
+      @media (min-width: $breakpoint-large-screen-860) {
         margin-bottom: -43px; // this is to compensate for the 17px line-height once at tablet size
       }
     }
@@ -81,17 +79,8 @@ $breakpoint-footer-margin: 25em;
     flex-wrap: wrap;
     justify-content: space-between;
     align-items: center;
-    max-width: 325px;
+    max-width: 20.3125rem; // 325px/16
     position: relative;
-
-    // each social media icon is an SVG with className="icon"
-    .icon {
-      fill: currentcolor;
-      position: relative;
-      transition: all ease-in-out 150ms;
-      bottom: 0;
-      right: 0;
-    }
 
     @media (min-width: $breakpoint-footer-margin) {
       margin: auto;
@@ -100,41 +89,39 @@ $breakpoint-footer-margin: 25em;
     a {
       position: relative;
       outline: none;
-      border: 2px solid transparent;
 
-      svg {
+      // each social media icon is an SVG with className="icon"
+      .icon {
+        fill: currentcolor;
+        position: relative;
+        bottom: 0;
+        right: 0;
         transition: all ease-in-out 150ms;
         width: 2.5625rem; /* 41px/16px */
         height: auto;
       }
-    }
 
-    @media screen and (prefers-reduced-motion: reduce) {
-      a:hover .icon,
-      a:focus-within .icon {
-        fill: var(--accent-color-icons);
-      }
+      @media (prefers-reduced-motion: no-preference) {
+        &:hover .icon,
+        &:focus-within .icon {
+          bottom: 0.5rem; // 8px/16
+          fill: var(--accent-color-icons);
 
-      @media (prefers-color-scheme: dark) {
-        a:hover .icon,
-        a:focus-within .icon {
-          fill: var(--accent-color);
+          @media (prefers-color-scheme: dark) {
+            bottom: 0.5rem; // 8px/16
+            fill: var(--accent-color);
+          }
         }
       }
-    }
 
-    @media screen and (prefers-reduced-motion: no-preference) {
-      a:hover .icon,
-      a:focus-within .icon {
-        bottom: 0.5rem; // 8px/16
-        fill: var(--accent-color-icons);
-      }
+      @media (prefers-reduced-motion: reduce) {
+        &:hover .icon,
+        &:focus-within .icon {
+          fill: var(--accent-color-icons);
 
-      @media (prefers-color-scheme: dark) {
-        a:hover .icon,
-        a:focus-within .icon {
-          bottom: 0.5rem; // 8px/16
-          fill: var(--accent-color);
+          @media (prefers-color-scheme: dark) {
+            fill: var(--accent-color);
+          }
         }
       }
     }

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -8,6 +8,15 @@ $breakpoint-tablet: 820px;
   font-size: map.get($font-sizes, "xs");
   color: var(--foreground-color);
 
+  @media (min-width: $breakpoint-scale-up) {
+    padding: 1rem 1.25rem 1rem 8.5625rem; // top: 16px/16; right: 20px/16; bottom: 16px/16; left: 137px/16
+    font-size: map.get($font-sizes, "sm");
+  }
+
+  @media (min-width: 100rem) {
+    margin: auto;
+  }
+
   // anchor tag
   &__link {
     outline: none;
@@ -18,14 +27,5 @@ $breakpoint-tablet: 820px;
     &:focus {
       border-bottom: 2px solid var(--accent-color);
     }
-  }
-
-  @media (min-width: $breakpoint-large-screen-860) {
-    padding: 1rem 1.25rem 1rem 8.5625rem; // top: 16px/16; right: 20px/16; bottom: 16px/16; left: 137px/16
-    font-size: map.get($font-sizes, "sm");
-  }
-
-  @media (min-width: 100rem) {
-    margin: auto;
   }
 }

--- a/src/styles/components/_home.scss
+++ b/src/styles/components/_home.scss
@@ -22,13 +22,40 @@ $breakpoint-top-section-scale-up: 70rem;
     @media (min-width: $breakpoint-top-section-margin) {
       margin: auto;
     }
+
+    @media (min-width: $breakpoint-large-screen-860) {
+      padding: 0 1.25rem 1.25rem 8.5625rem; // top&bottom: 0; right: 20px/16; left: 137px/16
+      display: flex;
+      flex-basis: 100%;
+      justify-content: space-between;
+      margin-top: 2rem;
+    }
   }
 
   &-top__text-column {
+    @media (min-width: $breakpoint-large-screen-860) {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      flex-basis: 45%;
+      padding-right: 1.875rem; // 30px/16
+    }
+
     h1 {
       font-size: 1.5625rem; // 25px/16
       font-weight: 400;
       line-height: 2.125rem; // 34px/16
+
+      @media (min-width: $breakpoint-large-screen-860) {
+        font-size: map.get($font-sizes, "md");
+        margin: 0;
+      }
+
+      @media (min-width: $breakpoint-top-section-scale-up) {
+        font-size: map.get($font-sizes, "xl");
+        margin: 0;
+        line-height: 4.1875rem; // 67px/16
+      }
     }
 
     p {
@@ -42,57 +69,9 @@ $breakpoint-top-section-scale-up: 70rem;
   &-top__top-image {
     width: 100%;
     margin: 3.75rem 0; // top&bottom: 60px/16; left&right: 0
-  }
 
-  &__date-updated {
-    font-family: Oxygen, sans-serif;
-    font-size: map.get($font-sizes, "xs");
-    text-align: center;
-    line-height: 1.75rem; // 28px/16
-    letter-spacing: 0.02em; // 2% in Figma
-  }
-
-  // these styles are NOT in the design, but are here to just fix up the
-  // visual experience for tablets
-  @media (min-width: $breakpoint-large-screen-860) {
-    &-top {
-      padding: 0 1.25rem 1.25rem 8.5625rem; // top&bottom: 0; right: 20px/16; left: 137px/16
-      display: flex;
-      flex-basis: 100%;
-      justify-content: space-between;
-      margin-top: 2rem;
-
-      &__text-column {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        flex-basis: 45%;
-        padding-right: 1.875rem; // 30px/16
-
-        h1 {
-          font-size: map.get($font-sizes, "md");
-          margin: 0;
-        }
-      }
-
-      &__top-image {
-        margin: 0;
-      }
-    }
-  }
-
-  // this is where the font styles in the designs are officially applied
-  @media (min-width: $breakpoint-top-section-scale-up) {
-    &-top {
-      h1 {
-        font-size: map.get($font-sizes, "xl");
-        margin: 0;
-        line-height: 4.1875rem; // 67px/16
-      }
-
-      p {
-        font-size: map.get($font-sizes, "sm");
-      }
+    @media (min-width: $breakpoint-large-screen-860) {
+      margin: 0;
     }
   }
 }

--- a/src/styles/components/_related-components.scss
+++ b/src/styles/components/_related-components.scss
@@ -9,11 +9,21 @@
     background-color: var(--background-color);
   }
 
+  @media (min-width: $breakpoint-large-screen-860) {
+    flex-direction: row;
+    gap: 15%;
+  }
+
   &__heading {
     position: relative;
     font-size: 25px;
     font-family: Viga, sans-serif;
     margin: 4rem 0;
+
+    @media (min-width: $breakpoint-large-screen-860) {
+      margin-top: 1rem;
+      max-width: 10rem;
+    }
 
     &::after {
       content: "";
@@ -30,10 +40,8 @@
       @media (prefers-color-scheme: dark) {
         filter: invert(1);
       }
-    }
 
-    @media (min-width: $breakpoint-scale-up) {
-      &::after {
+      @media (min-width: $breakpoint-scale-up) {
         right: 6rem;
         top: -3.25rem;
         width: 2.875rem; // 46px/16
@@ -49,6 +57,17 @@
     padding: 1rem 0;
     text-align: left;
     font-size: 18px;
+
+    @media (min-width: $breakpoint-large-screen-860) {
+      display: flex;
+      gap: 1rem 6rem;
+      flex-grow: 2;
+      font-size: map.get($font-sizes, "sm");
+      flex-flow: wrap column;
+      max-height: 10rem;
+      align-self: left;
+      text-align: left;
+    }
   }
 
   &__link {
@@ -64,35 +83,6 @@
       @media (prefers-color-scheme: dark) {
         outline: 1px solid var(--accent-color);
       }
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      &:hover,
-      &:focus {
-        outline: 1px solid var(--foreground-color);
-        text-decoration: none;
-      }
-    }
-  }
-
-  @media (min-width: $breakpoint-large-screen-860) {
-    flex-direction: row;
-    gap: 15%;
-
-    &__heading {
-      margin-top: 1rem;
-      max-width: 10rem;
-    }
-
-    &__list {
-      display: flex;
-      gap: 1rem 6rem;
-      flex-grow: 2;
-      font-size: map.get($font-sizes, "sm");
-      flex-flow: wrap column;
-      max-height: 10rem;
-      align-self: left;
-      text-align: left;
     }
   }
 }

--- a/src/styles/components/_specification-block.scss
+++ b/src/styles/components/_specification-block.scss
@@ -5,14 +5,63 @@
   line-height: 1.5625rem;
   letter-spacing: 0.02rem;
 
+  @media (min-width: $breakpoint-grid-large-screen-1115) {
+    display: grid;
+    column-gap: 5rem; // 80px /16
+    row-gap: 2.5rem; // 40px
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      "keyboard semantic"
+      "focus focus"
+      "aria aria"
+      "additional .";
+  }
+
   &__wrapper {
     display: block;
+
+    @media (min-width: $breakpoint-grid-large-screen-1115) {
+      margin: 0;
+
+      // focus expectations (1 column)
+      &:nth-child(1) {
+        grid-area: keyboard;
+      }
+
+      // semantic elements (1 column)
+      &:nth-child(2) {
+        grid-area: semantic;
+      }
+
+      // aria roles & attributes (full width)
+      &:nth-child(3) {
+        grid-area: aria;
+        max-width: 75ch;
+      }
+
+      // keyboard interactions (full-width)
+      &:nth-child(4) {
+        grid-area: focus;
+        max-width: 75ch;
+      }
+
+      // additional resources (1 column)
+      &:last-child {
+        li {
+          padding: 0.25rem 0; // top&bottom: 4px/16
+        }
+      }
+    }
   }
 
   &__heading {
     font-size: 1.5625rem;
     font-family: Viga, sans-serif;
     margin: 0;
+
+    @media (min-width: $breakpoint-grid-large-screen-1115) {
+      font-size: map.get($font-sizes, "md");
+    }
   }
 
   &__content {
@@ -26,6 +75,10 @@
 
   p {
     font-size: map.get($font-sizes, "xs");
+
+    @media (min-width: $breakpoint-grid-large-screen-1115) {
+      font-size: map.get($font-sizes, "sm");
+    }
   }
 
   li {
@@ -51,6 +104,17 @@
         background-size: contain;
       }
     }
+
+    @media (min-width: $breakpoint-grid-large-screen-1115) {
+      font-size: map.get($font-sizes, "sm");
+
+      &::before {
+        width: 0.8rem;
+        height: 1rem;
+        left: -1.5rem;
+        top: 0.4rem;
+      }
+    }
   }
 
   /* Adjacent sibling selector */
@@ -63,9 +127,14 @@
     font-family: Oxygen, sans-serif;
   }
 
+  // accordion subheaders (not on every detail page)
   h3 {
     font-size: map.get($font-sizes, "xs");
     font-weight: 700;
+
+    @media (min-width: $breakpoint-grid-large-screen-1115) {
+      font-size: map.get($font-sizes, "sm");
+    }
   }
 
   a {
@@ -73,102 +142,17 @@
     color: var(--foreground-color);
     transition: all ease-in-out 100ms;
     display: inline-block;
-  }
 
-  // hover/focus matched the footer text-links
-  @media (prefers-reduced-motion: no-preference) {
-    a:hover,
-    a:focus {
-      outline: 1px solid var(--foreground-color);
-      text-decoration: none;
-
-      @media (prefers-color-scheme: dark) {
-        outline: 1px solid var(--accent-color);
-      }
-    }
-  }
-
-  // matches the related components text-links
-  @media (prefers-reduced-motion: reduce) {
-    a {
-      transition: all ease-in-out 100ms;
-
+    // matches the related components text-links
+    @media (prefers-reduced-motion: no-preference) {
       &:hover,
       &:focus {
-        outline: 1px solid var(--accent-color);
+        outline: 1px solid var(--foreground-color);
         text-decoration: none;
-      }
-    }
-  }
 
-  @media (min-width: $breakpoint-grid-large-screen-1115) {
-    // grid of data fields & content (.cmp-specifications-block)
-    display: grid;
-    column-gap: 5rem; // 80px /16
-    row-gap: 2.5rem; // 40px
-    grid-template-columns: 1fr 1fr;
-    grid-template-areas:
-      "keyboard semantic"
-      "focus focus"
-      "aria aria"
-      "additional .";
-
-    p {
-      font-size: map.get($font-sizes, "sm");
-    }
-
-    li {
-      font-size: map.get($font-sizes, "sm");
-
-      &::before {
-        width: 0.8rem;
-        height: 1rem;
-        left: -1.5rem;
-        top: 0.4rem;
-      }
-    }
-
-    h3 {
-      font-size: map.get($font-sizes, "sm");
-    }
-
-    &__heading {
-      font-size: map.get($font-sizes, "md");
-    }
-
-    &__wrapper {
-      margin: 0;
-    }
-
-    // keyboard interactions (1 column)
-    &__wrapper:nth-child(1) {
-      // border: 1px solid red;
-      grid-area: keyboard;
-    }
-
-    // semantic elements (1 column)
-    &__wrapper:nth-child(2) {
-      // border: 1px solid blue;
-      grid-area: semantic;
-    }
-
-    // aria roles & attributes (full width)
-    &__wrapper:nth-child(3) {
-      // border: 1px solid black;
-      grid-area: aria;
-      max-width: 75ch;
-    }
-
-    // focus expectations (full-width)
-    &__wrapper:nth-child(4) {
-      // border: 1px solid green;
-      grid-area: focus;
-      max-width: 75ch;
-    }
-
-    &__wrapper:last-child {
-      li {
-        padding: 0.25rem 0; // top&bottom: 4px/16
+        @media (prefers-color-scheme: dark) {
+          outline: 1px solid var(--accent-color);
+        }
       }
     }
   }

--- a/src/styles/components/_usage-guidelines.scss
+++ b/src/styles/components/_usage-guidelines.scss
@@ -14,12 +14,27 @@ $breakpoint-usage-guidelines-display: 70rem;
     color: var(--font-color-dark);
   }
 
+  @media (min-width: $breakpoint-usage-guidelines-display) {
+    width: 100%;
+    max-width: 100rem;
+    display: flex;
+    flex-direction: row;
+
+    &__text {
+      max-width: 60ch;
+    }
+  }
+
   &__heading {
     position: relative;
     font-family: Viga, sans-serif;
     font-weight: 400;
     font-size: 1.5625rem;
     margin-top: 0;
+
+    @media (min-width: $breakpoint-usage-guidelines-display) {
+      font-size: map.get($font-sizes, "md");
+    }
   }
 
   &__image {
@@ -27,11 +42,22 @@ $breakpoint-usage-guidelines-display: 70rem;
     width: 80%;
     max-width: 30rem;
     margin: 0 auto -3rem;
+
+    @media (min-width: $breakpoint-usage-guidelines-display) {
+      position: relative;
+      width: 60%;
+      max-width: 35rem;
+      margin: -5rem auto;
+    }
   }
 
   p {
     line-height: 1.875rem;
     font-size: map.get($font-sizes, "xs");
+
+    @media (min-width: $breakpoint-usage-guidelines-display) {
+      font-size: map.get($font-sizes, "sm");
+    }
   }
 
   ul {
@@ -51,35 +77,6 @@ $breakpoint-usage-guidelines-display: 70rem;
       height: 1rem;
       left: -1.75rem;
       top: 0.5rem;
-    }
-  }
-}
-
-@media (min-width: $breakpoint-usage-guidelines-display) {
-  .cmp-usage-guidelines {
-    background-color: var(--accent-color-background);
-    width: 100%;
-    max-width: 100rem;
-    display: flex;
-    flex-direction: row;
-
-    p {
-      font-size: map.get($font-sizes, "sm");
-    }
-
-    &__heading {
-      font-size: map.get($font-sizes, "md");
-    }
-
-    &__text {
-      max-width: 60ch;
-    }
-
-    &__image {
-      position: relative;
-      width: 60%;
-      max-width: 35rem;
-      margin: -5rem auto;
     }
   }
 }

--- a/src/styles/elements/_elements.scss
+++ b/src/styles/elements/_elements.scss
@@ -1,3 +1,7 @@
+* {
+  box-sizing: border-box;
+}
+
 body {
   padding: 0;
   margin: 0;
@@ -26,8 +30,4 @@ a {
 h1 {
   font-size: map.get($font-sizes, "xl");
   font-family: Viga, sans-serif;
-}
-
-* {
-  box-sizing: border-box;
 }

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -18,15 +18,15 @@
 @import "./elements/kbd";
 
 /* LAYOUT/OBJECTS: objects, grids, flexbox etc */
+@import "./components/layout";
+@import "./components/component-grid";
 
 /* COMPONENTS: most of the work goes here! BEM classes, headers/footers/carousels, etc */
 @import "./components/home";
 @import "./components/details-page";
 @import "./components/header";
 @import "./components/component-card";
-@import "./components/component-grid";
 @import "./components/footer";
-@import "./components/layout";
 @import "./components/specification-block";
 @import "./components/definition";
 @import "./components/detailsBanner";

--- a/src/styles/tools/_functions.scss
+++ b/src/styles/tools/_functions.scss
@@ -1,6 +1,3 @@
 @function color($color) {
-  // @return map.get($colors, $color);
   @return var(--color-#{$color});
 }
-
-// background-color: color(blue);

--- a/src/styles/tools/_mixins.scss
+++ b/src/styles/tools/_mixins.scss
@@ -1,14 +1,12 @@
-$breakpoint-tablet: 820px;
-
 @mixin background-pattern() {
   background: url("../../../public/images/background_image.png");
   background-size: 100%;
 
-  @media screen and (prefers-color-scheme: dark) {
+  @media (prefers-color-scheme: dark) {
     background: url("../../../public/images/background_image_dark.svg");
   }
 
-  @media only screen and (min-width: $breakpoint-tablet) {
+  @media (min-width: $breakpoint-scale-up) {
     background-size: 30%;
   }
 }


### PR DESCRIPTION
### Description:

<!-- Add description of work done here -->
Refactoring was done in the SCSS files to ensure that media queries were not far removed from the elements they target. I divided up several long queries into shorter ones, and nested them within the selectors. 

### Spec:

Designs: [Figma file](https://www.figma.com/file/UjMQEwUvAsnFAMhYNdUiVT/Apprenticeship-Capstone?node-id=84%3A270&t=Z1mZXyHn90lItsyX-0)

See Story: [FSA22V2-297](https://sparkbox.atlassian.net/browse/FSA22V2-297)

### Validation:

<!-- Add description of work done here -->

- [x] This PR has code changes, and our linters still pass.

#### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
3. Run `npm install` to make sure you have all proper dependencies. (this project requires Node 16+)
4. Copy the `.env.example` file, making sure it's in the root of your project, and rename it `.env.local`. Search for "Accessible Components" in 1Password to find the API Key and Base ID. Add both of those secrets to your newly created `.env.local` file. That should establish your connection to our Airtable database.
5. Run `npm run lint` to confirm no errors.
6. Run `npm run test` to confirm all tests pass.
7. In terminal: `npm run dev`.
8. Check [localhost:3000](http://localhost:3000/) to see changes.
9. Run axe Devtools on affected pages to confirm no urgent errors.
10. Spot check homepage and interior pages to make sure nothing has visually broken. 

---
