### PR TITLE
FSA22V2-302 Refactor: rename component inventory

### DIFF
--- a/src/components/RelatedComponents.jsx
+++ b/src/components/RelatedComponents.jsx
@@ -1,7 +1,7 @@
 export default function RelatedComponents({ components }) {
   return (
     <div className="rel-component" data-testid="rel-component">
-      <h2 className="rel-component__heading">Component Inventory</h2>
+      <h2 className="rel-component__heading">Related Components</h2>
       <div className="rel-component__list">
         {components.map((cmt) => (
           <a


### PR DESCRIPTION
### Description:

<!-- Add description of work done here -->
Rename Component Inventory to Related Components

### Spec:

See Story: [FSA22V2-302](https://sparkbox.atlassian.net/browse/FSA22V2-302)

### Validation:

<!-- Add description of work done here -->

- [x] This PR has code changes, and our linters still pass.

#### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
3. Run `npm install` to make sure you have all proper dependencies. (this project requires Node 16+)
4. Copy the `.env.example` file, making sure it's in the root of your project, and rename it `.env.local`. Search for "Accessible Components" in 1Password to find the API Key and Base ID. Add both of those secrets to your newly created `.env.local` file. That should establish your connection to our Airtable database.
5. Run `npm run lint` to confirm no errors.
6. Run `npm run test` to confirm all tests pass.
7. In terminal: `npm run dev`.
8. Check [localhost:3000](http://localhost:3000/) to see changes.
9. Run axe Devtools on affected pages to confirm no urgent errors.
10. Check on interior pages that the "Related Components" heading shows instead of "Component Inventory

<!-- Additional validation steps below -->

