### PR TITLE
feat: eliminate h1 stacking at breakpoint

### DIFF
--- a/src/styles/components/_home.scss
+++ b/src/styles/components/_home.scss
@@ -37,7 +37,7 @@ $breakpoint-top-section-scale-up: 70rem;
       display: flex;
       flex-direction: column;
       justify-content: center;
-      flex-basis: 45%;
+      flex-basis: 0 0 60%;
       padding-right: 1.875rem; // 30px/16
     }
 
@@ -63,6 +63,7 @@ $breakpoint-top-section-scale-up: 70rem;
       margin: 1.25rem 0 0; // top: 20px/16; bottom&left&right: 0
       line-height: 1.75rem; // 28px/16
       letter-spacing: 0.02em;
+      max-width: 70ch;
     }
   }
 


### PR DESCRIPTION
FSA22V2-294

### Description:

- improve code within breakpoint-large-screen-860 to prevent h1 from stacking at that breakpoint.

### Spec:

Designs: [Designs](https://www.figma.com/file/UjMQEwUvAsnFAMhYNdUiVT/Apprenticeship-Capstone?node-id=244%3A2183&t=A0sL00y3exNBMMfW-0)

See Story: [FSA22V2-ISSUE](https://sparkbox.atlassian.net/browse/FSA22V2-294?atlOrigin=eyJpIjoiYTdlZTVmMmVlMDE5NDE3YWEwZTA3YzM1NGQ3YWNmYzciLCJwIjoiaiJ9)

### Validation:

<!-- Add description of work done here -->

- [ ] This PR has code changes, and our linters still pass.
- [ ] This PR affects production code, so it was browser tested (see below).
- [ ] This PR has new code, so new tests were added or updated, and they pass.

#### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
3. Run `npm install` to make sure you have all proper dependencies. (this project requires Node 16+)
4. Copy the `.env.example` file, making sure it's in the root of your project, and rename it `.env.local`. Search for "Accessible Components" in 1Password to find the API Key and Base ID. Add both of those secrets to your newly created `.env.local` file. That should establish your connection to our Airtable database.
5. Run `npm run lint` to confirm no errors.
6. Run `npm run test` to confirm all tests pass.
7. In terminal: `npm run dev`.
8. Check [localhost:3000](http://localhost:3000/) to see changes.
9. Run axe Devtools on affected pages to confirm no urgent errors.

<!-- Additional validation steps below -->

Open the site in the browser and see that h1 in hero section does not have stacking text between 820px - 950px. You may see the h1 stacking behavior at larger/smaller size screens but this card addresses only the breakpoint stated above. I will bring up the other breakpoint h1 stacking behaviors at standup.

### Pending Questions:

1.
2.

---

#### Browser Testing

<!--
The browser list should be tailored to specific engagement and client needs.
Delete if irrelevant to this issue
-->

In these browsers, behavior & design closely match original specifications. A user is able to access all content and functionality, including the usability of required assistive devices, such as keyboard and screenreader.

**macOS**

- [ ] Safari (last 2 major versions)
- [ ] Chrome (last 6 months)
- [ ] Firefox (last 6 months)

**Windows**

- [ ] Chrome (last 6 months)
- [ ] Firefox (last 6 months)
- [ ] Edge (last 6 months)

**Mobile**

- [ ] Safari (last 2 major versions)
- [ ] Chrome on Android (last 6 months)
- [ ] Firefox on Android (last 6 months)
