### PR TITLE
feat: add two column masonry layout

### DIFF
--- a/src/components/SpecificationBlock.jsx
+++ b/src/components/SpecificationBlock.jsx
@@ -1,6 +1,21 @@
-export default function SpecificationBlock({ heading, children }) {
+export default function SpecificationBlock({
+  heading,
+  children,
+  rowStart,
+  numberOfRows,
+  columnStart,
+  numberOfColumns,
+}) {
   return (
-    <div className="cmp-specifications-block__wrapper">
+    <div
+      className="cmp-specifications-block__wrapper"
+      style={{
+        '--column-start': columnStart,
+        '--number-of-columns': numberOfColumns,
+        '--row-start': rowStart,
+        '--number-of-rows': numberOfRows,
+      }}
+    >
       <h2
         className="cmp-specifications-block__heading"
         data-testid="spec-block-heading"

--- a/src/pages/[id].page.jsx
+++ b/src/pages/[id].page.jsx
@@ -8,6 +8,7 @@ import DetailsBanner from '../components/DetailsBanner';
 import UsageGuidelines from '../components/UsageGuidelines';
 import RichText from '../components/RichText';
 import CodeBlock from '../components/CodeBlock';
+import masonryDetails from '../utils/masonryDetails';
 
 export default function Details({ details }) {
   const {
@@ -66,7 +67,20 @@ export default function Details({ details }) {
       <div className="details-page__primary">
         <div className="cmp-specifications-block">
           {specificationBlocks.map((block) => (
-            <SpecificationBlock key={block.id} heading={block.heading}>
+            <SpecificationBlock
+              key={block.id}
+              heading={block.heading}
+              rowStart={masonryDetails[slug][block.heading]?.rowStart ?? 'auto'}
+              numberOfRows={
+                masonryDetails[slug][block.heading]?.numberOfRows ?? 1
+              }
+              columnStart={
+                masonryDetails[slug][block.heading]?.columnStart ?? 'auto'
+              }
+              numberOfColumns={
+                masonryDetails[slug][block.heading]?.numberOfColumns ?? 1
+              }
+            >
               <RichText markdown={block.content} />
             </SpecificationBlock>
           ))}

--- a/src/styles/components/_specification-block.scss
+++ b/src/styles/components/_specification-block.scss
@@ -1,55 +1,27 @@
 .cmp-specifications-block {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr;
   gap: 3.75rem;
   line-height: 1.5625rem;
   letter-spacing: 0.02rem;
 
-  @media (min-width: $breakpoint-grid-large-screen-1115) {
-    display: grid;
-    column-gap: 5rem; // 80px /16
-    row-gap: 2.5rem; // 40px
+  @media (min-width: $breakpoint-specifications-grid-two-column) {
     grid-template-columns: 1fr 1fr;
-    grid-template-areas:
-      "keyboard semantic"
-      "focus focus"
-      "aria aria"
-      "additional .";
-  }
 
-  &__wrapper {
-    display: block;
+    @supports (grid-template-rows: masonry) {
+      grid-template-rows: masonry;
+    }
 
-    @media (min-width: $breakpoint-grid-large-screen-1115) {
-      margin: 0;
+    @supports not (grid-template-rows: masonry) {
+      &__wrapper {
+        --row-start: auto;
+        --number-of-rows: 1;
+        --column-start: auto;
+        --number-of-columns: 1;
 
-      // focus expectations (1 column)
-      &:nth-child(1) {
-        grid-area: keyboard;
-      }
-
-      // semantic elements (1 column)
-      &:nth-child(2) {
-        grid-area: semantic;
-      }
-
-      // aria roles & attributes (full width)
-      &:nth-child(3) {
-        grid-area: aria;
         max-width: 75ch;
-      }
-
-      // keyboard interactions (full-width)
-      &:nth-child(4) {
-        grid-area: focus;
-        max-width: 75ch;
-      }
-
-      // additional resources (1 column)
-      &:last-child {
-        li {
-          padding: 0.25rem 0; // top&bottom: 4px/16
-        }
+        grid-row: var(--row-start, 1) / span var(--number-of-rows, 1);
+        grid-column: var(--column-start, 1) / span var(--number-of-columns, 1);
       }
     }
   }

--- a/src/styles/settings/_breakpoints.scss
+++ b/src/styles/settings/_breakpoints.scss
@@ -1,3 +1,4 @@
 $breakpoint-large-screen-860: 54rem;
 $breakpoint-grid-large-screen-1115: 72rem;
 $breakpoint-scale-up: 51rem;
+$breakpoint-specifications-grid-two-column: 59.375rem; // 950px

--- a/src/utils/masonryDetails.js
+++ b/src/utils/masonryDetails.js
@@ -1,0 +1,97 @@
+const masonryDetails = {
+  accordion: {
+    'Focus Expectations': {
+      rowStart: 1,
+      numberOfRows: 1,
+    },
+    'Semantic Elements': {
+      rowStart: 1,
+      numberOfRows: 1,
+    },
+    'Aria Attributes': {
+      rowStart: 'auto',
+      numberOfRows: 1,
+    },
+    'Keyboard Interactions': {
+      rowStart: 2,
+      numberOfRows: 1,
+    },
+    'Additional Resources': {
+      rowStart: 2,
+      numberOfRows: 1,
+    },
+  },
+  dialog: {
+    'Keyboard Interactions': {
+      rowStart: 1,
+      numberOfRows: 2,
+    },
+    'Focus Expectations': {
+      rowStart: 3,
+      numberOfRows: 1,
+      columnStart: 2,
+    },
+    'Semantic Elements': {
+      rowStart: 1,
+      numberOfRows: 1,
+    },
+    'Aria Attributes': {
+      rowStart: 3,
+      numberOfRows: 1,
+      columnStart: 1,
+    },
+    'Additional Resources': {
+      rowStart: 2,
+      numberOfRows: 1,
+    },
+  },
+  disclosure: {
+    'Focus Expectations': {
+      rowStart: 1,
+      numberOfRows: 1,
+    },
+    'Semantic Elements': {
+      rowStart: 1,
+      numberOfRows: 1,
+    },
+    'Aria Attributes': {
+      rowStart: 3,
+      numberOfRows: 1,
+      columnStart: 1,
+    },
+    'Keyboard Interactions': {
+      rowStart: 2,
+      numberOfColumns: 2,
+    },
+    'Additional Resources': {
+      rowStart: 3,
+      numberOfRows: 1,
+      columnStart: 1,
+    },
+  },
+  tabs: {
+    'Focus Expectations': {
+      rowStart: 1,
+      numberOfRows: 1,
+    },
+    'Semantic Elements': {
+      rowStart: 2,
+      numberOfRows: 1,
+      columnStart: 2,
+    },
+    'Aria Attributes': {
+      rowStart: 2,
+      numberOfRows: 1,
+    },
+    'Keyboard Interactions': {
+      rowStart: 3,
+      numberOfRows: 1,
+    },
+    'Additional Resources': {
+      rowStart: 1,
+      numberOfRows: 1,
+    },
+  },
+};
+
+export default masonryDetails;


### PR DESCRIPTION
FSA22V2-292

### Description:

- add two column masonry layout to specifications grid.

### Spec:

Designs: [Designs](https://www.figma.com/file/UjMQEwUvAsnFAMhYNdUiVT/Apprenticeship-Capstone?node-id=84%3A663&t=BPQNtzeTJP9dm997-0)

See Story: [FSA22V2-ISSUE](https://sparkbox.atlassian.net/browse/FSA22V2-ISSUE)

### Validation:

<!-- Add description of work done here -->

- [ ] This PR has code changes, and our linters still pass.
- [ ] This PR affects production code, so it was browser tested (see below).
- [ ] This PR has new code, so new tests were added or updated, and they pass.

#### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
3. Run `npm install` to make sure you have all proper dependencies. (this project requires Node 16+)
4. Copy the `.env.example` file, making sure it's in the root of your project, and rename it `.env.local`. Search for "Accessible Components" in 1Password to find the API Key and Base ID. Add both of those secrets to your newly created `.env.local` file. That should establish your connection to our Airtable database.
5. Run `npm run lint` to confirm no errors.
6. Run `npm run test` to confirm all tests pass.
7. In terminal: `npm run dev`.
8. Check [localhost:3000](http://localhost:3000/) to see changes.
9. Run axe Devtools on affected pages to confirm no urgent errors.

<!-- Additional validation steps below -->


2.

---

#### Browser Testing

<!--
The browser list should be tailored to specific engagement and client needs.
Delete if irrelevant to this issue
-->

In these browsers, behavior & design closely match original specifications. A user is able to access all content and functionality, including the usability of required assistive devices, such as keyboard and screenreader.

**macOS**

- [ ] Safari (last 2 major versions)
- [ ] Chrome (last 6 months)
- [ ] Firefox (last 6 months)

**Windows**

- [ ] Chrome (last 6 months)
- [ ] Firefox (last 6 months)
- [ ] Edge (last 6 months)

**Mobile**

- [ ] Safari (last 2 major versions)
- [ ] Chrome on Android (last 6 months)
- [ ] Firefox on Android (last 6 months)
