### PR TITLE
FSA22V2-304: Refactor: Adjust the details page banner

### DIFF
--- a/src/components/DetailsBanner.jsx
+++ b/src/components/DetailsBanner.jsx
@@ -1,10 +1,32 @@
+import Header from './Header';
+
+const isWideImage = (name) => {
+  const wideImages = ['Tabs', 'Table'];
+  if (wideImages.includes(name)) {
+    return true;
+  }
+  return false;
+};
+
 export default function DetailsBanner({ name, image }) {
   const { src, alt } = image; // destructure from image object
   return (
     <div className="details-banner">
+      <section
+        className="details-banner__header"
+        data-testid="accessible-components-homepage-link"
+      >
+        <Header />
+      </section>
       <h1>{name}</h1>
       <div className="details-banner-image">
         <img src={src} alt={alt} />
+        {!isWideImage(name) && (
+          <>
+            <img src={src} alt={alt} />
+            <img src={src} alt={alt} />
+          </>
+        )}
       </div>
     </div>
   );
@@ -13,3 +35,5 @@ export default function DetailsBanner({ name, image }) {
 DetailsBanner.defaultProps = {
   image: { alt: ' ' },
 };
+
+export { isWideImage };

--- a/src/components/DetailsBanner.test.jsx
+++ b/src/components/DetailsBanner.test.jsx
@@ -1,23 +1,62 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import DetailsBanner from './DetailsBanner';
+import DetailsBanner, { isWideImage } from './DetailsBanner';
 
-it('Displays the banner header based on component name prop', () => {
-  const headerText = 'The header';
-  render(<DetailsBanner name={headerText} />);
+describe('DetailsBanner', () => {
+  it('Displays the banner h1 based on component name prop', () => {
+    const headingText = 'The header';
+    render(<DetailsBanner name={headingText} />);
+    const headingElement = screen.getByRole('heading');
+    expect(headingElement).toBeInTheDocument();
+  });
 
-  const headerElement = screen.queryByText(headerText);
-  expect(headerElement).toBeInTheDocument();
-});
+  it('Displays the banner image based on component name prop', () => {
+    const image = {
+      src: 'http://some-url.com/',
+      alt: 'test alt tag',
+    };
+    render(<DetailsBanner image={image} />);
 
-it('Displays the banner image based on component name prop', () => {
-  const image = {
-    src: 'http://some-url.com/',
-    alt: 'test alt tag',
-  };
-  render(<DetailsBanner image={image} />);
+    // from testing-library doc https://testing-library.com/docs/queries/byalttext/
+    const bannerImages = screen.getAllByAltText(image.alt); // pass string in to test
+    expect(bannerImages[0].src).toBe(image.src);
+    expect(bannerImages[1].src).toBe(image.src);
+    expect(bannerImages[2].src).toBe(image.src);
+  });
 
-  // from testing-library doc https://testing-library.com/docs/queries/byalttext/
-  const bannerImage = screen.getByAltText(image.alt); // pass string in to test
-  expect(bannerImage.src).toBe(image.src);
+  it('returns false when isWideImage is false', () => {
+    const interiorHeading = 'Accordion';
+    render(<DetailsBanner name={interiorHeading} />);
+    const result = isWideImage(interiorHeading);
+    expect(result).toBe(false);
+  });
+
+  it('returns true when isWideImage is true', () => {
+    const interiorHeading = 'Table';
+    render(<DetailsBanner name={interiorHeading} />);
+    const result = isWideImage(interiorHeading);
+    expect(result).toBe(true);
+  });
+
+  it('returns 3 images if isWideImage returns false', () => {
+    const image = {
+      src: 'http://some-url.com/',
+      alt: 'test alt tag',
+    };
+    const interiorHeading = 'Dialog';
+    render(<DetailsBanner name={interiorHeading} image={image} />);
+    const bannerImages = screen.getAllByAltText(image.alt);
+    expect(bannerImages).toHaveLength(3);
+  });
+
+  it('returns 1 image if isWideImage returns true', () => {
+    const image = {
+      src: 'http://some-url.com/',
+      alt: 'test alt tag',
+    };
+    const interiorHeading = 'Tabs';
+    render(<DetailsBanner name={interiorHeading} image={image} />);
+    const bannerImages = screen.getAllByAltText(image.alt);
+    expect(bannerImages).toHaveLength(1);
+  });
 });

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 export default function Header() {
   return (
-    <header className="cmp-header" data-testid="header">
+    <header className="cmp-header">
       <Link href="/" aria-label="To home page" className="cmp-header__link">
         Accessible Components
       </Link>

--- a/src/components/Header.test.jsx
+++ b/src/components/Header.test.jsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import Header from './Header';
+
+describe('Header', () => {
+  it('renders the Header component/link', () => {
+    render(<Header />);
+    const header = screen.getByText('Accessible Components');
+    expect(header).toBeInTheDocument();
+  });
+});

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Header from './Header';
 import Footer from './Footer';
 
 function formatTitle(title) {
@@ -19,7 +18,6 @@ export default function Layout({ children, pageTitle }) {
         <link rel="icon" href="/images/favicon.png" />
       </Head>
       <div className="page-container">
-        <Header />
         <main className="content">{children}</main>
         <Footer />
       </div>

--- a/src/components/Layout.test.jsx
+++ b/src/components/Layout.test.jsx
@@ -2,12 +2,6 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import Layout from './Layout';
 
-it('Renders a Header component', () => {
-  render(<Layout pageTitle="testTitle" />);
-  const header = screen.queryByTestId('header');
-  expect(header).toBeTruthy();
-});
-
 it('Renders a Footer component', () => {
   render(<Layout pageTitle="testTitle" />);
   const footer = screen.getByTestId('footer');

--- a/src/pages/index.page.jsx
+++ b/src/pages/index.page.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Layout from '../components/Layout';
+import Header from '../components/Header';
 import ComponentCard from '../components/ComponentCard';
 
 export default function Home() {
@@ -7,6 +8,7 @@ export default function Home() {
     <Layout pageTitle="Home">
       <div className="home">
         <div className="home-wrapper">
+          <Header />
           <div className="home-top">
             <div className="home-top__text-column">
               <h1>Accessibility Cheatsheets for Components</h1>

--- a/src/styles/components/_details-page.scss
+++ b/src/styles/components/_details-page.scss
@@ -5,7 +5,7 @@
     background-image: url("../../../public/images/background_image.png");
     background-size: cover;
     background-position: center;
-    padding: 3.75rem 1.25rem;
+    padding: 0 1.25rem;
 
     @media (prefers-color-scheme: dark) {
       background-image: url("../../../public/images/background_image-light.svg");

--- a/src/styles/components/_detailsBanner.scss
+++ b/src/styles/components/_detailsBanner.scss
@@ -27,17 +27,39 @@
 
   &-image {
     box-sizing: border-box;
-    width: 100%;
-    background-color: var(--light-background-color);
+    background-color: var(--background-color);
     border: 2px solid var(--foreground-color);
-
-    @media (prefers-color-scheme: dark) {
-      border: 2px solid var(--background-color);
-    }
+    display: flex;
+    align-items: center;
+    justify-content: space-evenly;
 
     img {
-      width: 100%;
-      max-height: 45rem;
+      max-width: 100%;
+      min-width: 0;
+      height: auto;
+      max-height: 30rem; // 480px/16
+
+      @media (prefers-color-scheme: dark) {
+        filter: invert(1);
+      }
+    }
+
+    & img:nth-child(2),
+    & img:nth-child(3) {
+      display: none;
+
+      @media (min-width: $breakpoint-scale-up) {
+        display: block;
+      }
+    }
+  }
+
+  &__header {
+    padding: 0;
+    margin-left: -1.25rem;
+
+    @media (min-width: $breakpoint-scale-up) {
+      margin-left: -8.5625rem;
     }
   }
 }

--- a/src/styles/components/_home.scss
+++ b/src/styles/components/_home.scss
@@ -2,11 +2,17 @@ $breakpoint-top-section-margin: 70rem;
 $breakpoint-top-section-scale-up: 70rem;
 
 // listing/home page
-// everything below the SB logo & above the footer
+// everything below the homepage link & above the footer
 .home {
   @include background-pattern;
 
   width: 100%;
+
+  @media (min-width: $breakpoint-scale-up) {
+    // this adjusts the homepage to better match the interior page margins and
+    // puts the header link in a more consistent spot
+    margin-top: 5rem; // 80px/16;
+  }
 
   &-wrapper {
     background-color: var(--background-color);


### PR DESCRIPTION
### Description:

<!-- Add description of work done here -->
Some refactoring had to be done in order to limit the height of the interior page banners. With taller images, that banner was very long, so a new max-height was put on the images, as well as creating a new grid for multiple illustrations of the components in the banner section. Lastly, the header component needed to be located in a different place in order to inherit the background image of the details banner.

### Spec:

Designs: 
![Screenshot 2022-11-18 at 11 26 34 AM](https://user-images.githubusercontent.com/69602589/204599186-9f2fdaa0-81d4-43ee-89f5-0e04f5e7dc8b.png)

With Jelly's input, the background of the image grid has changed to a solid color in order to prevent the component illustrations from competing with the background image. She also requested 5rem from the top of the homepage link to the top of the viewport. Both of these changes are not found in the screenshot above, but can be seen on the site. 


See Story: [FSA22V2-304](https://sparkbox.atlassian.net/browse/FSA22V2-304)

### Validation:

<!-- Add description of work done here -->

- [x] This PR has code changes, and our linters still pass.
- [x] This PR affects production code, so it was browser tested (see below).
- [x] This PR has new code, so new tests were added or updated, and they pass.

#### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
3. Run `npm install` to make sure you have all proper dependencies. (this project requires Node 16+)
4. Copy the `.env.example` file, making sure it's in the root of your project, and rename it `.env.local`. Search for "Accessible Components" in 1Password to find the API Key and Base ID. Add both of those secrets to your newly created `.env.local` file. That should establish your connection to our Airtable database.
5. Run `npm run lint` to confirm no errors.
6. Run `npm run test` to confirm all tests pass.
7. In terminal: `npm run dev`.
8. Check [localhost:3000](http://localhost:3000/) to see changes.
9. Run axe Devtools on affected pages to confirm no urgent errors.
10. When switching between light & dark mode, no breaking visual changes should occur. Each details page has a new banner layout similar to above. 

<!-- Additional validation steps below -->

#### Pending Question
1. When on the details page, can we target just the tabs illustration to show up as a single image instead of 3? 


---

#### Browser Testing

<!--
The browser list should be tailored to specific engagement and client needs.
Delete if irrelevant to this issue
-->

In these browsers, behavior & design closely match original specifications. A user is able to access all content and functionality, including the usability of required assistive devices, such as keyboard and screenreader.

**macOS**

- [x] Safari (last 2 major versions)
- [x] Chrome (last 6 months)
- [x] Firefox (last 6 months)

**Windows**

- [x] Chrome (last 6 months)
- [x] Firefox (last 6 months)
- [x] Edge (last 6 months)

**Mobile**

- [x] Safari (last 2 major versions)
- [x] Chrome on Android (last 6 months)
- [x] Firefox on Android (last 6 months)
