### PR TITLE
FSA22V2-316: Refactor: Line-height units & calculations

### DIFF
--- a/src/styles/components/_code-block.scss
+++ b/src/styles/components/_code-block.scss
@@ -9,7 +9,7 @@ $breakpoint-increase-padding: $breakpoint-scale-up;
   &__heading {
     font-size: map.get($font-sizes, "mobile-heading");
     font-family: Viga, sans-serif;
-    line-height: 2.125rem; // 34px/16
+    line-height: map.get($line-heights, "lg"); // approx. 34px/24
     margin-inline: auto;
     position: relative;
 
@@ -32,7 +32,7 @@ $breakpoint-increase-padding: $breakpoint-scale-up;
 
     @media (min-width: $breakpoint-increase-content-font-size) {
       font-size: map.get($font-sizes, "md");
-      line-height: 2.5rem; // 40px/16
+      line-height: map.get($line-heights, "lg"); // approx. 45px/32
 
       &::after {
         width: 2.2rem;
@@ -43,10 +43,9 @@ $breakpoint-increase-padding: $breakpoint-scale-up;
 
   &__content {
     padding: 1.875rem 1.25rem; // top&bottom: 30px/16; left&right: 20px/16
-    // background-color: map.get($colors, "white");
     color: var(--foreground-color);
-    line-height: 1.75rem; // 28px/16
     font-size: map.get($font-sizes, "xs");
+    line-height: map.get($line-heights, "lg"); // approx. 22px/16
     font-family: Oxygen, sans-serif;
     letter-spacing: 0.02em; // 2% in Figma
     margin-top: 1rem;
@@ -73,12 +72,13 @@ $breakpoint-increase-padding: $breakpoint-scale-up;
   code {
     margin: 0;
     font-size: map.get($font-sizes, "xs");
-    line-height: 1.75rem; // 28px/16
+    line-height: map.get($line-heights, "xl"); // approx. 28px/16
     letter-spacing: 0.02em; // 2% in Figma
     font-family: Oxygen, sans-serif;
 
     @media (min-width: $breakpoint-increase-codeblock-font) {
       font-size: map.get($font-sizes, "sm");
+      line-height: map.get($line-heights, "lg"); // approx. 28px/20
     }
   }
 }

--- a/src/styles/components/_component-card.scss
+++ b/src/styles/components/_component-card.scss
@@ -39,12 +39,15 @@
       font-weight: 700;
       z-index: 1;
       font-size: map.get($font-sizes, "sm");
-      line-height: 4.6667rem; // 75px
+      line-height: map.get($line-heights, "lg"); // 28px/20
       letter-spacing: 0.02em;
+      height: 5.5rem; // 88px/16
       background-color: var(--light-background-color);
       position: relative;
       text-align: center;
-      display: block;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       border-top: 0.25rem solid var(--foreground-color);
 
       @media (prefers-color-scheme: dark) {

--- a/src/styles/components/_definition.scss
+++ b/src/styles/components/_definition.scss
@@ -1,7 +1,6 @@
 $breakpoint-background-image-size: 75rem;
 
 .cmp-definition {
-  line-height: 1.75rem;
   color: var(--foreground-color);
   width: 100%;
   position: relative;
@@ -36,6 +35,7 @@ $breakpoint-background-image-size: 75rem;
   // the entire text column
   &__content {
     font-size: map.get($font-sizes, "xs");
+    line-height: map.get($line-heights, "xl"); // approx. 28px/16
     letter-spacing: 0.02rem;
     max-width: 100rem;
 
@@ -46,6 +46,7 @@ $breakpoint-background-image-size: 75rem;
     @media (min-width: $breakpoint-scale-up) {
       position: relative;
       font-size: map.get($font-sizes, "sm");
+      line-height: map.get($line-heights, "lg"); // approx. 28px/20
       padding: 2.5rem 8.5625rem;
     }
   }
@@ -55,6 +56,7 @@ $breakpoint-background-image-size: 75rem;
     font-family: Viga, sans-serif;
     font-weight: 400;
     font-size: map.get($font-sizes, "mobile-heading");
+    line-height: map.get($line-heights, "lg"); // approx. 34px/24
     margin: 0;
 
     /* Circle around "definition" */

--- a/src/styles/components/_detailsBanner.scss
+++ b/src/styles/components/_detailsBanner.scss
@@ -1,27 +1,19 @@
 .details-banner {
-  line-height: 2.125rem;
-  letter-spacing: 0.02em; // 2% in Figma
   max-width: 82.875rem; // compensates for 8.5625rem padding on left/right
 
   @media only screen and (min-width: 100rem) {
     margin: auto;
   }
 
-  @media (min-width: $breakpoint-scale-up) {
-    font-size: map.get($font-sizes, "xl");
-    line-height: 1.34; // 70px/52 (get the line-height number from the target-line-height/font-size)
-  }
-
   h1 {
     margin: 1.875rem 0; // top&bottom: 30px/16; left&right: 0
-    line-height: 2.125rem; // 34px/16
+    line-height: map.get($line-heights, "lg"); // approx. 34px/24
     letter-spacing: 0;
     font-family: Viga, sans-serif;
     font-size: map.get($font-sizes, "mobile-heading");
 
     @media (min-width: $breakpoint-scale-up) {
       font-size: map.get($font-sizes, "xl");
-      line-height: 1.34; // 70px/52
     }
   }
 

--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -19,13 +19,13 @@ $breakpoint-footer-margin: 25em;
     padding: 3.75rem 0; /* top&bottom: 60px/16; left&right: 0 */
     font-size: map.get($font-sizes, "sm");
     margin: auto;
-    line-height: 1.5rem; /* 24px/16 */
+    line-height: map.get($line-heights, "md"); /* 22px/20 */
     transition: 500ms color;
     letter-spacing: 0.02em; // 2% in Figma
 
     @media (min-width: $breakpoint-large-screen-860) {
-      line-height: 1.0625rem; /* 17px/16 */
       font-size: map.get($font-sizes, "sm");
+      line-height: map.get($line-heights, "sm"); // 20px/20
     }
   }
 

--- a/src/styles/components/_header.scss
+++ b/src/styles/components/_header.scss
@@ -5,6 +5,7 @@
   letter-spacing: 0.02em; // other letter-spacing in Figma is the same
   font-size: map.get($font-sizes, "xs");
   color: var(--foreground-color);
+  line-height: map.get($line-heights, "lg"); // approx. 22px/16
 
   @media (min-width: $breakpoint-scale-up) {
     padding: 1rem 1.25rem 1rem 8.5625rem; // top: 16px/16; right: 20px/16; bottom: 16px/16; left: 137px/16

--- a/src/styles/components/_home.scss
+++ b/src/styles/components/_home.scss
@@ -49,7 +49,7 @@ $breakpoint-top-section-scale-up: 70rem;
       h1 {
         font-size: map.get($font-sizes, "mobile-heading");
         font-weight: 400;
-        line-height: 1.21; // 34px/28
+        line-height: map.get($line-heights, "lg"); // approx. 34px/24
 
         @media (min-width: $breakpoint-scale-up) {
           font-size: map.get($font-sizes, "md");
@@ -59,19 +59,19 @@ $breakpoint-top-section-scale-up: 70rem;
         @media (min-width: $breakpoint-grid-large-screen-1115) {
           font-size: map.get($font-sizes, "xl");
           margin: 0;
-          line-height: 1.34; // 70px/52
         }
       }
 
       p {
         font-size: map.get($font-sizes, "xs");
         margin: 1.25rem 0 0; // top: 20px/16; bottom&left&right: 0
-        line-height: 1.75; // 28px/16
+        line-height: map.get($line-heights, "xl"); // 28px/16
         letter-spacing: 0.02em;
         max-width: 70ch;
 
         @media (min-width: $breakpoint-scale-up) {
           font-size: map.get($font-sizes, "sm");
+          line-height: map.get($line-heights, "lg"); // 28px/20
         }
       }
     }

--- a/src/styles/components/_related-components.scss
+++ b/src/styles/components/_related-components.scss
@@ -19,12 +19,14 @@ $breakpoint-move-arrow-left: 38.125rem; // 610px/16
   &__heading {
     position: relative;
     font-size: map.get($font-sizes, "mobile-heading");
+    line-height: map.get($line-heights, "lg"); // approx. 34px/24
     font-family: Viga, sans-serif;
     margin: 4rem 0;
 
     @media (min-width: $breakpoint-large-screen-860) {
       margin-top: 1rem;
       max-width: 10rem;
+      font-size: map.get($font-sizes, "md");
     }
 
     &::after {
@@ -62,15 +64,16 @@ $breakpoint-move-arrow-left: 38.125rem; // 610px/16
     padding: 1rem 0;
     text-align: left;
     font-size: map.get($font-sizes, "sm");
+    line-height: map.get($line-heights, "lg"); // 28px/20
 
-    @media (min-width: $breakpoint-large-screen-860) {
+    @media (min-width: $breakpoint-scale-up) {
       display: flex;
       gap: 1rem 6rem;
       flex-grow: 2;
       font-size: map.get($font-sizes, "sm");
-      flex-flow: wrap column;
+      flex-flow: wrap row;
+      align-items: flex-start;
       max-height: 10rem;
-      align-self: left;
       text-align: left;
     }
   }

--- a/src/styles/components/_specification-block.scss
+++ b/src/styles/components/_specification-block.scss
@@ -89,6 +89,7 @@
 
   &__heading {
     font-size: map.get($font-sizes, "mobile-heading");
+    line-height: map.get($line-heights, "lg"); // approx. 34px/24
     font-family: Viga, sans-serif;
     margin: 0;
 
@@ -97,17 +98,13 @@
     }
   }
 
-  &__content {
-    font-size: map.get($font-sizes, "sm");
-  }
-
   ul {
-    line-height: 1.5625rem;
     margin-left: 2rem;
   }
 
   p {
     font-size: map.get($font-sizes, "xs");
+    line-height: map.get($line-heights, "lg"); // approx. 22px/16
 
     @media (min-width: $breakpoint-grid-large-screen-1115) {
       font-size: map.get($font-sizes, "sm");
@@ -119,6 +116,7 @@
     margin-top: 1.25rem;
     font-weight: 400;
     font-size: map.get($font-sizes, "xs");
+    line-height: map.get($line-heights, "lg"); // approx. 22px/16
     letter-spacing: 175%;
 
     &::before {
@@ -159,6 +157,7 @@
   // accordion subheaders (not on every detail page)
   h3 {
     font-size: map.get($font-sizes, "xs");
+    line-height: map.get($line-heights, "lg"); // approx. 22px/16
     font-weight: 700;
 
     @media (min-width: $breakpoint-grid-large-screen-1115) {

--- a/src/styles/components/_usage-guidelines.scss
+++ b/src/styles/components/_usage-guidelines.scss
@@ -30,6 +30,7 @@ $breakpoint-usage-guidelines-display: 70rem;
     font-family: Viga, sans-serif;
     font-weight: 400;
     font-size: map.get($font-sizes, "mobile-heading");
+    line-height: map.get($line-heights, "lg"); // approx. 34px/24
     margin-top: 0;
 
     @media (min-width: $breakpoint-usage-guidelines-display) {
@@ -52,11 +53,12 @@ $breakpoint-usage-guidelines-display: 70rem;
   }
 
   p {
-    line-height: 1.875rem;
     font-size: map.get($font-sizes, "xs");
+    line-height: map.get($line-heights, "xl"); // 28px/16
 
     @media (min-width: $breakpoint-usage-guidelines-display) {
       font-size: map.get($font-sizes, "sm");
+      line-height: map.get($line-heights, "lg"); // 28px/20
     }
   }
 
@@ -67,7 +69,7 @@ $breakpoint-usage-guidelines-display: 70rem;
   li {
     position: relative;
     font-size: map.get($font-sizes, "xs");
-    line-height: 1.75; // 28px/16
+    line-height: map.get($line-heights, "xl"); // approx. 28px/16
 
     &::before {
       content: "";
@@ -83,7 +85,7 @@ $breakpoint-usage-guidelines-display: 70rem;
 
     @media (min-width: $breakpoint-usage-guidelines-display) {
       font-size: map.get($font-sizes, "sm");
-      line-height: 1.5; // 30px/20
+      line-height: map.get($line-heights, "lg"); // approx. 28px/20
     }
   }
 }

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -3,6 +3,7 @@
 @import "./settings/colors";
 @import "./settings/font_map";
 @import "./settings/breakpoints";
+@import "./settings/line_height_map";
 
 /* TOOLS: mixins, etc */
 @import "./tools/mixins";

--- a/src/styles/settings/_line_height_map.scss
+++ b/src/styles/settings/_line_height_map.scss
@@ -1,0 +1,7 @@
+// Variables for Line-Heights
+$line-heights: (
+  "sm": 1, // 1:1 with font-size
+  "md": 1.1, // 10% larger than font-size
+  "lg": 1.4, // 40% larger than font-size
+  "xl": 1.75 // 75% larger than font-size
+);


### PR DESCRIPTION
### Description:

<!-- Add description of work done here -->
-Add a line-height map to keep all line-height values in one place. 
-Remove units on line-height properties and recalculate appropriately with current font sizes, instead of base font-size.

**Note:** when we initially built the component cards, the line-height in Figma was 75px. That has since been changed, but we never updated it. When I put in the more accurate 28px for the card headers, it no longer matched the designs. That's why I had to add the height and flex properties.

### Spec:

See Story: [FSA22V2-316](https://sparkbox.atlassian.net/browse/FSA22V2-316)

### Validation:

<!-- Add description of work done here -->

- [x] This PR has code changes, and our linters still pass.

#### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
3. Run `npm install` to make sure you have all proper dependencies. (this project requires Node 16+)
4. Copy the `.env.example` file, making sure it's in the root of your project, and rename it `.env.local`. Search for "Accessible Components" in 1Password to find the API Key and Base ID. Add both of those secrets to your newly created `.env.local` file. That should establish your connection to our Airtable database.
5. Run `npm run lint` to confirm no errors.
6. Run `npm run test` to confirm all tests pass.
7. In terminal: `npm run dev`.
8. Check [localhost:3000](http://localhost:3000/) to see changes.
9. Run axe Devtools on affected pages to confirm no urgent errors.
10. Spot check with inspector to ensure line-heights are displaying properly. 

<!-- Additional validation steps below -->

