### PR TITLE
feat: add masonry layout for specification blocks

### DIFF
--- a/src/styles/components/_specification-block.scss
+++ b/src/styles/components/_specification-block.scss
@@ -1,7 +1,7 @@
 .cmp-specifications-block {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 3.75rem;
+  gap: 4rem;
   line-height: 1.5625rem;
   letter-spacing: 0.02rem;
 
@@ -20,8 +20,8 @@
         --number-of-columns: 1;
 
         max-width: 75ch;
-        grid-row: var(--row-start, 1) / span var(--number-of-rows, 1);
-        grid-column: var(--column-start, 1) / span var(--number-of-columns, 1);
+        grid-row: var(--row-start, auto) / span var(--number-of-rows, 1);
+        grid-column: var(--column-start, auto) / span var(--number-of-columns, 1);
       }
     }
   }

--- a/src/utils/masonryDetails.js
+++ b/src/utils/masonryDetails.js
@@ -8,41 +8,46 @@ const masonryDetails = {
       rowStart: 1,
       numberOfRows: 1,
     },
-    'Aria Attributes': {
-      rowStart: 'auto',
-      numberOfRows: 1,
+    'ARIA Roles and Attributes': {
+      rowStart: 2,
+      numberOfRows: 3,
+      columnStart: 1,
     },
     'Keyboard Interactions': {
       rowStart: 2,
-      numberOfRows: 1,
+      numberOfRows: 2,
+      columnStart: 2,
     },
     'Additional Resources': {
-      rowStart: 2,
-      numberOfRows: 1,
+      rowStart: 4,
+      numberOfRows: 3,
     },
   },
   dialog: {
-    'Keyboard Interactions': {
+    'Focus Expectations': {
       rowStart: 1,
       numberOfRows: 2,
-    },
-    'Focus Expectations': {
-      rowStart: 3,
-      numberOfRows: 1,
-      columnStart: 2,
+      columnStart: 1,
     },
     'Semantic Elements': {
       rowStart: 1,
       numberOfRows: 1,
+      columnStart: 2,
     },
-    'Aria Attributes': {
+    'ARIA Roles and Attributes': {
       rowStart: 3,
-      numberOfRows: 1,
+      numberOfRows: 4,
       columnStart: 1,
     },
-    'Additional Resources': {
+    'Keyboard Interactions': {
       rowStart: 2,
+      numberOfRows: 3,
+      columnStart: 2,
+    },
+    'Additional Resources': {
+      rowStart: 4,
       numberOfRows: 1,
+      columnStart: 2,
     },
   },
   disclosure: {
@@ -54,19 +59,19 @@ const masonryDetails = {
       rowStart: 1,
       numberOfRows: 1,
     },
-    'Aria Attributes': {
-      rowStart: 3,
-      numberOfRows: 1,
-      columnStart: 1,
+    'ARIA Roles and Attributes': {
+      rowStart: 2,
+      numberOfRows: 3,
     },
     'Keyboard Interactions': {
       rowStart: 2,
-      numberOfColumns: 2,
+      numberOfRows: 1,
+      columnStart: 2,
     },
+
     'Additional Resources': {
       rowStart: 3,
       numberOfRows: 1,
-      columnStart: 1,
     },
   },
   tabs: {
@@ -75,21 +80,22 @@ const masonryDetails = {
       numberOfRows: 1,
     },
     'Semantic Elements': {
-      rowStart: 2,
-      numberOfRows: 1,
+      rowStart: 1,
+      numberOfRows: 2,
       columnStart: 2,
     },
-    'Aria Attributes': {
+    'ARIA Roles and Attributes': {
       rowStart: 2,
-      numberOfRows: 1,
+      numberOfRows: 3,
+      columnStart: 1,
     },
     'Keyboard Interactions': {
       rowStart: 3,
-      numberOfRows: 1,
+      numberOfRows: 3,
+      columnStart: 2,
     },
     'Additional Resources': {
-      rowStart: 1,
-      numberOfRows: 1,
+      rowStart: 5,
     },
   },
 };


### PR DESCRIPTION
- create mock masonry layout for specification blocks that will work on web browsers that do not support grid-template-rows masonry setting.

FSA22V2-319

### Description:

<!-- Add description of work done here -->

### Spec:

Designs: [Designs](DESIGN_URL)

See Story: [FSA22V2-ISSUE](https://sparkbox.atlassian.net/browse/FSA22V2-ISSUE)

### Validation:

<!-- Add description of work done here -->

- [ ] This PR has code changes, and our linters still pass.
- [ ] This PR affects production code, so it was browser tested (see below).
- [ ] This PR has new code, so new tests were added or updated, and they pass.

#### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
3. Run `npm install` to make sure you have all proper dependencies. (this project requires Node 16+)
4. Copy the `.env.example` file, making sure it's in the root of your project, and rename it `.env.local`. Search for "Accessible Components" in 1Password to find the API Key and Base ID. Add both of those secrets to your newly created `.env.local` file. That should establish your connection to our Airtable database.
5. Run `npm run lint` to confirm no errors.
6. Run `npm run test` to confirm all tests pass.
7. In terminal: `npm run dev`.
8. Check [localhost:3000](http://localhost:3000/) to see changes.
9. Run axe Devtools on affected pages to confirm no urgent errors.

<!-- Additional validation steps below -->

### Pending Questions:

1.
2.

---

#### Browser Testing

<!--
The browser list should be tailored to specific engagement and client needs.
Delete if irrelevant to this issue
-->

In these browsers, behavior & design closely match original specifications. A user is able to access all content and functionality, including the usability of required assistive devices, such as keyboard and screenreader.

**macOS**

- [ ] Safari (last 2 major versions)
- [ ] Chrome (last 6 months)
- [ ] Firefox (last 6 months)

**Windows**

- [ ] Chrome (last 6 months)
- [ ] Firefox (last 6 months)
- [ ] Edge (last 6 months)

**Mobile**

- [ ] Safari (last 2 major versions)
- [ ] Chrome on Android (last 6 months)
- [ ] Firefox on Android (last 6 months)
