### PR TITLE
Styling: decrease size of footer contents

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -10,18 +10,18 @@ export default function Footer() {
   return (
     <footer className="default-footer" data-testid="footer">
       <div className="default-footer__content">
-        <div className="default-footer__item">
+        <div className="default-footer__item default-footer__item--text">
           {'This site was proudly built by '}
           <a href="https://sparkbox.com">Sparkbox</a>
           {' apprentices.'}
         </div>
-        <div className="default-footer__item">
+        <div className="default-footer__item default-footer__item--text">
           <a href="https://apprentices.sparkbox.com/">
             Learn more about Sparkbox&#39;s apprenticeship programs.
           </a>
         </div>
         <div className="default-footer__item">
-          <div className="default-footer__links">
+          <div className="default-footer__icon-container">
             <a
               href="https://twitter.com/hearsparkbox"
               aria-label="Twitter link"
@@ -48,7 +48,7 @@ export default function Footer() {
             </a>
           </div>
         </div>
-        <div className="default-footer__item">
+        <div className="default-footer__item default-footer__item--text">
           {`©${currentYear} Sparkbox. All rights reserved. `}
           <a href="https://sparkbox.com/privacypolicy">Privacy Policy</a>
           {' and '}

--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -9,22 +9,16 @@ $breakpoint-footer-margin: 25em;
 
   // Content wrapper
   &__content {
-    min-height: 20.75rem; /* 332px/16 */
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
-    align-items: center;
-    gap: 3.75rem; // 60px/16
+    gap: 2.25rem; // 60px/16
     text-align: center;
-    padding: 3.75rem 0; /* top&bottom: 60px/16; left&right: 0 */
-    font-size: map.get($font-sizes, "sm");
-    margin: auto;
-    line-height: map.get($line-heights, "md"); /* 22px/20 */
+    padding: 1.5rem 0; /* top&bottom: 60px/16px; left&right: 0 */
+    font-size: map.get($font-sizes, "xs");
     transition: 500ms color;
     letter-spacing: 0.02em; // 2% in Figma
 
     @media (min-width: $breakpoint-large-screen-860) {
-      font-size: map.get($font-sizes, "sm");
       line-height: map.get($line-heights, "sm"); // 20px/20
     }
   }
@@ -35,12 +29,12 @@ $breakpoint-footer-margin: 25em;
     width: 100%;
 
     // the first line of the footer has a smaller margin-bottom than the rest of the footer items.
-    // this compensates for that
+    // this compensates for that.
     &:first-child {
-      margin-bottom: -1.875rem; // 30px/16
+      margin-bottom: -1.25rem; // 30px/16
 
-      @media (min-width: $breakpoint-large-screen-860) {
-        margin-bottom: -43px; // this is to compensate for the 17px line-height once at tablet size
+      @media (min-width: $breakpoint-scale-up) {
+        margin-bottom: -1.5rem; // this is to compensate for the 17px line-height once at tablet size
       }
     }
   }
@@ -79,7 +73,7 @@ $breakpoint-footer-margin: 25em;
     flex-wrap: wrap;
     justify-content: space-between;
     align-items: center;
-    max-width: 20.3125rem; // 325px/16
+    max-width: 16rem; // 325px/16
     position: relative;
 
     @media (min-width: $breakpoint-footer-margin) {
@@ -89,15 +83,15 @@ $breakpoint-footer-margin: 25em;
     a {
       position: relative;
       outline: none;
+      padding-right: 0.2rem;
 
       // each social media icon is an SVG with className="icon"
       .icon {
         fill: currentcolor;
         position: relative;
         bottom: 0;
-        right: 0;
         transition: all ease-in-out 150ms;
-        width: 2.5625rem; /* 41px/16 */
+        width: 1.5rem; /* 24px */
         height: auto;
       }
 

--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -15,60 +15,50 @@ $breakpoint-footer-margin: 25em;
     text-align: center;
     padding: 1.5rem 0; /* top&bottom: 60px/16px; left&right: 0 */
     font-size: map.get($font-sizes, "xs");
-    transition: 500ms color;
     letter-spacing: 0.02em; // 2% in Figma
-
-    @media (min-width: $breakpoint-large-screen-860) {
-      line-height: map.get($line-heights, "sm"); // 20px/20
-    }
+    color: var(--foreground-color);
   }
 
   // Flex items of content wrapper
   &__item {
-    color: var(--foreground-color);
     width: 100%;
 
-    // the first line of the footer has a smaller margin-bottom than the rest of the footer items.
-    // this compensates for that.
+    // first line of text needs extra space below it.
     &:first-child {
-      margin-bottom: -1.25rem; // 30px/16
-
-      @media (min-width: $breakpoint-scale-up) {
-        margin-bottom: -1.5rem; // this is to compensate for the 17px line-height once at tablet size
-      }
-    }
-  }
-
-  // text-links
-  &__item > a {
-    text-decoration: underline;
-    color: var(--font-color);
-    background: linear-gradient(to left, transparent 50%, var(--accent-color) 50%);
-    background-size: 201% 100%;
-    background-position: right bottom;
-    transition: ease-in-out all 250ms;
-    outline: none;
-
-    @media (prefers-reduced-motion: no-preference) {
-      &:hover,
-      &:focus-within {
-        color: var(--font-color-dark);
-        background-position: left bottom;
-      }
+      margin-bottom: -1.5rem; // 30px/16
     }
 
-    @media (prefers-reduced-motion: reduce) {
-      &:hover,
-      &:focus-within {
-        color: var(--font-color-dark);
-        background-color: var(--accent-color);
+    // Underline links and give them animations
+    &--text a {
+      text-decoration: underline;
+      color: var(--font-color);
+      background: linear-gradient(to left, transparent 50%, var(--accent-color) 50%);
+      background-size: 201% 100%;
+      background-position: right bottom;
+      transition: ease-in-out all 250ms;
+      outline: none;
+
+      @media (prefers-reduced-motion: no-preference) {
+        &:hover,
+        &:focus-within {
+          color: var(--font-color-dark);
+          background-position: left bottom;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        &:hover,
+        &:focus-within {
+          color: var(--font-color-dark);
+          background-color: var(--accent-color);
+        }
       }
     }
   }
 
   // Container for social media icons
-  &__links {
-    margin: 0 1rem; // top&bottom: 0; left&right: 16px
+  &__icon-container {
+    margin: auto; // top&bottom: 0; left&right: 16px
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
@@ -76,16 +66,11 @@ $breakpoint-footer-margin: 25em;
     max-width: 16rem; // 325px/16
     position: relative;
 
-    @media (min-width: $breakpoint-footer-margin) {
-      margin: auto;
-    }
-
     a {
       position: relative;
-      outline: none;
       padding-right: 0.2rem;
 
-      // each social media icon is an SVG with className="icon"
+      // classname on the <svg> tags
       .icon {
         fill: currentcolor;
         position: relative;


### PR DESCRIPTION
### Description:

- Reduces the size of footer contents: icons are 30% smaller, and text is decreased from 20px to 16px.
- Margins/padding reduced to fit the proportions of the original design.
- Simplifies CSS slightly by removing redundant values

### Spec:

Designs: Intentionally strays from [the Figma design](https://www.figma.com/file/UjMQEwUvAsnFAMhYNdUiVT/Apprenticeship-Capstone?node-id=84%3A270&t=siw0s6v4jF6pxW5R-0). The 16px font and smaller icons were approved by Merani.

See Story: [FSA22V2-286](https://sparkbox.atlassian.net/browse/FSA22V2-286)

### Validation:

<!-- Add description of work done here -->

- [x] This PR has code changes, and our linters still pass.

#### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
3. Run `npm install` to make sure you have all proper dependencies. (this project requires Node 16+)
4. Copy the `.env.example` file, making sure it's in the root of your project, and rename it `.env.local`. Search for "Accessible Components" in 1Password to find the API Key and Base ID. Add both of those secrets to your newly created `.env.local` file. That should establish your connection to our Airtable database.
5. Run `npm run lint` to confirm no errors.
6. Run `npm run test` to confirm all tests pass.
7. In terminal: `npm run dev`.
8. Check [localhost:3000](http://localhost:3000/) to see changes.
9. Run axe Devtools on affected pages to confirm no urgent errors.