### PR TITLE
FSA22V2-312: Refactor: Code Elements are no longer blue

### DIFF
--- a/src/styles/components/_specification-block.scss
+++ b/src/styles/components/_specification-block.scss
@@ -151,7 +151,8 @@
 
   code {
     color: var(--code-color);
-    font-family: Oxygen, sans-serif;
+    padding: 0 4px;
+    border-radius: 0.5rem;
   }
 
   // accordion subheaders (not on every detail page)

--- a/src/styles/generics/_root.scss
+++ b/src/styles/generics/_root.scss
@@ -12,7 +12,7 @@
   --accent-color-background: var(--color-accent-pink);
   --font-color: var(--color-black);
   --font-color-highlight: var(--color-black);
-  --code-color: var(--color-blue-light-mode);
+  --code-color: var(--color-code-color-light-mode);
 
   @media (prefers-color-scheme: dark) {
     --background-color: var(--color-black);
@@ -22,6 +22,6 @@
     --font-color: var(--color-white);
     --font-color-dark: var(--color-black);
     --font-color-highlight: var(--accent-color);
-    --code-color: var(--color-blue-dark-mode);
+    --code-color: var(--color-code-color-dark-mode);
   }
 }

--- a/src/styles/settings/_colors.scss
+++ b/src/styles/settings/_colors.scss
@@ -1,8 +1,8 @@
 $colors: (
   "black": #000,
   "white": #fff,
-  "blue-light-mode": #225ffc,
-  "blue-dark-mode": #34b2ff,
+  "code-color-light-mode": #02855e,
+  "code-color-dark-mode": #fe3cb0,
   "accent-teal": #01f5ac,
   "accent-pink": #fe3cb0,
   "accent-gray": #747575


### PR DESCRIPTION
### Description:

<!-- Add description of work done here -->

In the specification blocks, the code tags were originally designed to be blue. We have changed that so they are not misunderstood to be links. Additionally, the font was changed to the default monospace `code` font to ensure these elements are clearly  distinguished from the rest of the content.

### Spec:
BEFORE: 
<img width="370" alt="Screen Shot 2022-12-13 at 12 14 06 PM" src="https://user-images.githubusercontent.com/69602589/207434976-2a301915-5b9e-43ec-a2d7-adec75a38b76.png">
<img width="370" alt="Screen Shot 2022-12-13 at 12 13 28 PM" src="https://user-images.githubusercontent.com/69602589/207435015-c3859fcf-0b71-4383-b0c1-495ce533d276.png">

AFTER:
<img width="523" alt="Screen Shot 2022-12-13 at 2 58 38 PM" src="https://user-images.githubusercontent.com/69602589/207435199-da17ef08-09a5-4903-b16e-89614116d238.png">
<img width="523" alt="Screen Shot 2022-12-13 at 2 58 48 PM" src="https://user-images.githubusercontent.com/69602589/207435206-273bacbb-4e5e-4207-8136-aea0830ceab1.png">


See Story: [FSA22V2-312](https://sparkbox.atlassian.net/browse/FSA22V2-312)

### Validation:

<!-- Add description of work done here -->

- [x] This PR has code changes, and our linters still pass.
- [x] This PR affects production code, so it was browser tested (see below).

#### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
3. Run `npm install` to make sure you have all proper dependencies. (this project requires Node 16+)
4. Copy the `.env.example` file, making sure it's in the root of your project, and rename it `.env.local`. Search for "Accessible Components" in 1Password to find the API Key and Base ID. Add both of those secrets to your newly created `.env.local` file. That should establish your connection to our Airtable database.
5. Run `npm run lint` to confirm no errors.
6. Run `npm run test` to confirm all tests pass.
7. In terminal: `npm run dev`.
8. Check [localhost:3000](http://localhost:3000/) to see changes.
9. Run axe Devtools on affected pages to confirm no urgent errors.
10. If you switch between dark and light mode, the new code elements should change from a green to a pink text color. 

<!-- Additional validation steps below -->

---

#### Browser Testing

<!--
The browser list should be tailored to specific engagement and client needs.
Delete if irrelevant to this issue
-->

In these browsers, behavior & design closely match original specifications. A user is able to access all content and functionality, including the usability of required assistive devices, such as keyboard and screenreader.

**macOS**

- [x] Safari (last 2 major versions)
- [x] Chrome (last 6 months)
- [x] Firefox (last 6 months)

**Windows**

- [x] Chrome (last 6 months)
- [x] Firefox (last 6 months)
- [x] Edge (last 6 months)

**Mobile**

- [x] Safari (last 2 major versions)
- [x] Chrome on Android (last 6 months)
- [x] Firefox on Android (last 6 months)
