### PR TITLE
FSA22V2-326: Feat: Add 404 page styles

### DIFF
--- a/src/components/ErrorContent.jsx
+++ b/src/components/ErrorContent.jsx
@@ -1,0 +1,19 @@
+export default function ErrorContent() {
+  return (
+    <section className="error-page__wrapper">
+      <section className="error-page__content">
+        <h1 className="error-page__heading">404 Not Found</h1>
+        <p className="error-page__message">
+          We couldn&#39;t find the page you were looking for.
+        </p>
+        <p className="error-page__message">Enjoy Max instead!</p>
+      </section>
+      <section className="error-page__image">
+        <img
+          src="/images/max-grid.svg"
+          alt="Illustration of cute small white terrier dog with tongue out and head turned left looking like he is curious"
+        />
+      </section>
+    </section>
+  );
+}

--- a/src/pages/404.page.jsx
+++ b/src/pages/404.page.jsx
@@ -1,11 +1,16 @@
-import Link from 'next/link';
 import Layout from '../components/Layout';
+import Header from '../components/Header';
+import ErrorContent from '../components/ErrorContent';
 
 export default function ErrorPage() {
   return (
     <Layout pageTitle="404">
-      <h1>404 Not Found</h1>
-      <Link href="/">Overview Page</Link>
+      <div className="error-page">
+        <section className="error-page__header">
+          <Header />
+        </section>
+        <ErrorContent />
+      </div>
     </Layout>
   );
 }

--- a/src/styles/components/_404.scss
+++ b/src/styles/components/_404.scss
@@ -1,0 +1,83 @@
+.error-page {
+  @media (min-width: $breakpoint-scale-up) {
+    padding-bottom: 5rem; // this should mirror the header padding
+  }
+
+  &__header {
+    padding: 0;
+
+    @media (min-width: $breakpoint-scale-up) {
+      padding-top: 5rem;
+    }
+  }
+
+  &__wrapper {
+    width: 100%;
+  }
+
+  &__content {
+    padding: 0 1.25rem;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+    max-width: 100rem;
+
+    @media (min-width: $breakpoint-scale-up) {
+      padding: 1.25rem 1.25rem 1.25rem 8.5625rem; // top: 20px/16; right: 20px/16; bottom: 20px/16; left: 137px/16
+    }
+
+    @media (min-width: 100rem) {
+      margin: auto;
+    }
+  }
+
+  &__heading {
+    color: var(--foreground-color);
+    font-size: map.get($font-sizes, "mobile-heading");
+    line-height: map.get($line-heights, "lg");
+    letter-spacing: 0.02em;
+    margin: 0;
+
+    @media (min-width: $breakpoint-scale-up) {
+      font-size: map.get($font-sizes, "xl");
+    }
+  }
+
+  &__message {
+    margin: 0;
+    color: var(--foreground-color);
+    font-size: map.get($font-sizes, "xs");
+    line-height: map.get($line-heights, "md");
+    letter-spacing: 0.02em;
+
+    @media (min-width: $breakpoint-scale-up) {
+      font-size: map.get($font-sizes, "sm");
+    }
+  }
+
+  &__image {
+    margin-top: 2rem;
+    padding: 1.25rem;
+    align-self: center;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    background-image: url("../../../public/images/background_image.png");
+    background-color: var(--background-color);
+    background-size: cover;
+    background-position: center;
+
+    @media (prefers-color-scheme: dark) {
+      background-image: url("../../../public/images/background_image_dark.svg");
+    }
+
+    @media (min-width: $breakpoint-scale-up) {
+      background-size: 50%;
+    }
+
+    img {
+      max-width: 50%;
+    }
+  }
+}

--- a/src/styles/components/_footer.scss
+++ b/src/styles/components/_footer.scss
@@ -3,8 +3,6 @@ $breakpoint-footer-margin: 25em;
 .default-footer {
   background-color: var(--background-color);
   width: 100%;
-  position: relative;
-  bottom: 0;
   padding: 1.25rem; // 20px/16
 
   // Content wrapper

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -36,6 +36,9 @@
 @import "./components/usage-guidelines";
 @import "./components/code-block";
 @import "./components/sandpack";
-@import "./components/component-link"
+@import "./components/404";
+@import "./components/component-link";
+
 /* VENDORS: third-party */
+
 /* UTILITIES: one offs, display:hidden, backgrounds, margin, padding, etc */

--- a/src/styles/layout/_layout.scss
+++ b/src/styles/layout/_layout.scss
@@ -1,4 +1,11 @@
 .page-container {
   position: relative;
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+
+  // this continues to push the footer all the way to the bottom
+  .content {
+    flex: 1;
+  }
 }


### PR DESCRIPTION
### Description:

<!-- Add description of work done here -->
Give the 404 page similar styles to the rest of the project. After speaking with Kaitlyn and double checking the copy, this included adding a few contextual sentences, a homepage link, and our image of Max! 

### Spec:

See Story: [FSA22V2-326](https://sparkbox.atlassian.net/browse/FSA22V2-326)

### Validation:

<!-- Add description of work done here -->

- [x] This PR has code changes, and our linters still pass.
- [x] This PR affects production code, so it was browser tested (see below).

#### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
3. Run `npm install` to make sure you have all proper dependencies. (this project requires Node 16+)
4. Copy the `.env.example` file, making sure it's in the root of your project, and rename it `.env.local`. Search for "Accessible Components" in 1Password to find the API Key and Base ID. Add both of those secrets to your newly created `.env.local` file. That should establish your connection to our Airtable database.
5. Run `npm run lint` to confirm no errors.
6. Run `npm run test` to confirm all tests pass.
7. In terminal: `npm run dev`.
8. Check [localhost:3000](http://localhost:3000/) to see changes.
9. Run axe Devtools on affected pages to confirm no urgent errors.
10. Go to an invalid component page (like `/alert` or `/wrong`. You should a newly styled 404 page. 

<!-- Additional validation steps below -->

---

#### Browser Testing

<!--
The browser list should be tailored to specific engagement and client needs.
Delete if irrelevant to this issue
-->

In these browsers, behavior & design closely match original specifications. A user is able to access all content and functionality, including the usability of required assistive devices, such as keyboard and screenreader.

**macOS**

- [x] Safari (last 2 major versions)
- [x] Chrome (last 6 months)
- [x] Firefox (last 6 months)

**Windows**

- [x] Chrome (last 6 months)
- [x] Firefox (last 6 months)
- [x] Edge (last 6 months)

**Mobile**

- [x] Safari (last 2 major versions)
- [x] Chrome on Android (last 6 months)
- [x] Firefox on Android (last 6 months)
