### PR TITLE
FSA22V2-321: Fix style problems on home page

### DIFF
--- a/src/styles/components/_component-link.scss
+++ b/src/styles/components/_component-link.scss
@@ -5,11 +5,18 @@
   height: 100%;
   background-color: var(--background-color);
 
-  &:focus .component-card {
+  // tabbed focus has rotation
+  &:focus-visible .component-card {
     position: relative;
     z-index: 1;
     outline: 2px solid var(--accent-color);
     outline-offset: 2px;
     transform: rotate(2deg);
+  }
+
+  // click focus has no rotation
+  &:focus:not(:focus-visible) .component-card {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
   }
 }

--- a/src/styles/components/_details-banner.scss
+++ b/src/styles/components/_details-banner.scss
@@ -7,7 +7,6 @@
 
   h1 {
     margin: 1.875rem 0; // top&bottom: 30px/16; left&right: 0
-    line-height: map.get($line-heights, "lg"); // approx. 34px/24
     letter-spacing: 0;
     font-family: Viga, sans-serif;
     font-size: map.get($font-sizes, "mobile-heading");

--- a/src/styles/components/_home.scss
+++ b/src/styles/components/_home.scss
@@ -49,7 +49,6 @@ $breakpoint-top-section-scale-up: 70rem;
       h1 {
         font-size: map.get($font-sizes, "mobile-heading");
         font-weight: 400;
-        line-height: map.get($line-heights, "lg"); // approx. 34px/24
 
         @media (min-width: $breakpoint-scale-up) {
           font-size: map.get($font-sizes, "md");

--- a/src/styles/elements/_elements.scss
+++ b/src/styles/elements/_elements.scss
@@ -30,4 +30,5 @@ a {
 h1 {
   font-size: map.get($font-sizes, "xl");
   font-family: Viga, sans-serif;
+  line-height: calc(1em + 0.5rem);
 }

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -31,7 +31,7 @@
 @import "./components/footer";
 @import "./components/specification-block";
 @import "./components/definition";
-@import "./components/detailsBanner";
+@import "./components/details-banner";
 @import "./components/related-components";
 @import "./components/usage-guidelines";
 @import "./components/code-block";

--- a/src/styles/layout/_component-grid.scss
+++ b/src/styles/layout/_component-grid.scss
@@ -56,7 +56,19 @@ $breakpoint-accordion-medium-550: 34rem;
 
     @media (min-width: $breakpoint-scale-up) {
       display: grid;
-      list-style: none;
+      grid-template-rows: repeat(4, minmax(0, 0.8fr));
+      grid-template-areas:
+        "accordion dialog"
+        "accordion disclosure"
+        " tabs tabs"
+        "max-scott max-scott";
+    }
+
+    @media (min-width: $breakpoint-grid-large-screen-1115) {
+      grid-template-columns: unset;
+      grid-template-columns: 1fr 1fr 1fr;
+      grid-template-rows: unset;
+      grid-template-rows: repeat(3, minmax(0, 0.8fr));
       grid-template-areas:
         "accordion dialog disclosure"
         "accordion tabs tabs"


### PR DESCRIPTION
### Description:

<!-- Add description of work done here -->
Some minor style fixes were implemented to continue to refine and match the homepage designs. This PR includes: 
- Refactoring the grid columns & rows to be a consistent size (using `fr` and `repeat`)
- Add an additional 2-column grid layout to accommodate more "medium" sized screens
- Use `:focus:not(:focus-visible)` on the component cards to prevent them from rotating when you click on them, but not when you tab to them
- Because the 1.4 value seemed too large, use `calc` to adjust the line-heights of all `h1` headings. 

### Spec:

See Story: [FSA22V2-321](https://sparkbox.atlassian.net/browse/FSA22V2-321)

### Validation:

<!-- Add description of work done here -->

- [x] This PR has code changes, and our linters still pass.
- [x] This PR affects production code, so it was browser tested (see below).

#### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
3. Run `npm install` to make sure you have all proper dependencies. (this project requires Node 16+)
4. Copy the `.env.example` file, making sure it's in the root of your project, and rename it `.env.local`. Search for "Accessible Components" in 1Password to find the API Key and Base ID. Add both of those secrets to your newly created `.env.local` file. That should establish your connection to our Airtable database.
5. Run `npm run lint` to confirm no errors.
6. Run `npm run test` to confirm all tests pass.
7. In terminal: `npm run dev`.
8. Check [localhost:3000](http://localhost:3000/) to see changes.
9. Run axe Devtools on affected pages to confirm no urgent errors.
10. On the homepage, resize the browser to see the grid change between a 1-, 2- and 3-column layout.
11. Tab through the homepage, until you get to your component of choice. Your tabbed component should be rotated slightly. Keeping that tabbed focus, with your cursor, click on a different component. When you click, you should not see that clicked component rotate. 

<!-- Additional validation steps below -->

---

#### Browser Testing

<!--
The browser list should be tailored to specific engagement and client needs.
Delete if irrelevant to this issue
-->

In these browsers, behavior & design closely match original specifications. A user is able to access all content and functionality, including the usability of required assistive devices, such as keyboard and screenreader.

**macOS**

- [x] Safari (last 2 major versions)
- [x] Chrome (last 6 months)
- [x] Firefox (last 6 months)

**Windows**

- [x] Chrome (last 6 months)
- [x] Firefox (last 6 months)
- [x] Edge (last 6 months)

**Mobile**

- [x] Safari (last 2 major versions)
- [x] Chrome on Android (last 6 months)
- [x] Firefox on Android (last 6 months)
