### PR TITLE
chore: check for the new board's card numbers

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 Designs: [Designs](DESIGN_URL)
 
-See Story: [FSA22V2-ISSUE](https://sparkbox.atlassian.net/browse/FSA22V2-ISSUE)
+See Story: [Jira card](https://sparkbox.atlassian.net/browse/AC-CARD_NUMBER)
 
 ### Validation:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,48 +4,48 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
-    branches: [ "main" ]
+    branches: ['main']
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   check-commit-message:
-      name: Check Commit Message
-      runs-on: ubuntu-latest
+    name: Check Commit Message
+    runs-on: ubuntu-latest
 
-      steps:
-        - name: Check commit message type
-          uses: gsactions/commit-message-checker@v1
-          with:
-            pattern: '^((:art:|:racehorse:|:non-potable_water:|:memo:|:penguin:|:apple:|:checkered_flag:|:bug:|:fire:|:green_heart:|:white_check_mark:|:lock:|:arrow_up:|:arrow_down:|:shirt:) )?(feat|fix|docs|style|refactor|test|chore).+'
-            error: 'Commit messages must begin with a valid commit type.'
-            excludeDescription: 'true'
-            excludeTitle: 'true'
-            checkAllCommitMessages: 'true'
-            accessToken: ${{ secrets.GITHUB_TOKEN }}
-        - name: Check commit message ticket number
-          uses: gsactions/commit-message-checker@v1
-          with:
-            pattern: 'FSA22V2-[0-9]+$'
-            error: 'Commit messages must end with a ticket number.'
-            excludeDescription: 'true'
-            excludeTitle: 'true'
-            checkAllCommitMessages: 'true'
-            accessToken: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check commit message type
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^((:art:|:racehorse:|:non-potable_water:|:memo:|:penguin:|:apple:|:checkered_flag:|:bug:|:fire:|:green_heart:|:white_check_mark:|:lock:|:arrow_up:|:arrow_down:|:shirt:) )?(feat|fix|docs|style|refactor|test|chore).+'
+          error: 'Commit messages must begin with a valid commit type.'
+          excludeDescription: 'true'
+          excludeTitle: 'true'
+          checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check commit message ticket number
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: 'AC-[0-9]+$'
+          error: 'Commit messages must end with a ticket number.'
+          excludeDescription: 'true'
+          excludeTitle: 'true'
+          checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
 
   build:
-      runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-      env:
-        AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
-        AIRTABLE_BASE_ID: ${{ secrets.AIRTABLE_BASE_ID }}
+    env:
+      AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
+      AIRTABLE_BASE_ID: ${{ secrets.AIRTABLE_BASE_ID }}
 
-      strategy:
-        matrix:
-          node-version: [ 16.x ]
+    strategy:
+      matrix:
+        node-version: [16.x]
 
-      steps:
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 


### PR DESCRIPTION
### Description:

<!-- Add description of work done here -->
This updates the GitHub Action that checks commit message formatting to look for the new Jira board's card number format: "AC-" instead of "FSA22V2-"

### Spec:

See Story: [Jira card](https://sparkbox.atlassian.net/browse/AC-1)

#### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
