### PR TITLE
refactor: change image prop names to defaultImage and hoverImage

### DIFF
--- a/src/components/ComponentCard.jsx
+++ b/src/components/ComponentCard.jsx
@@ -1,18 +1,17 @@
 import Link from 'next/link';
 
 export default function ComponentCard({
-  name, slug, imageOpen, imageClosed,
+  name,
+  slug,
+  defaultImage,
+  hoverImage,
 }) {
   return (
     <Link href={slug} className="component-link" data-cy="component-card">
       <div className="component-card">
         <span className="component-card__header">{name}</span>
-        <img src={imageOpen} alt="" className="component-card__image-open" />
-        <img
-          src={imageClosed}
-          alt=""
-          className="component-card__image-closed"
-        />
+        <img src={defaultImage} alt="" className="component-card__image-open" />
+        <img src={hoverImage} alt="" className="component-card__image-closed" />
       </div>
     </Link>
   );

--- a/src/pages/index.page.jsx
+++ b/src/pages/index.page.jsx
@@ -54,8 +54,8 @@ export default function Home({ details }) {
                 <ComponentCard
                   name={item['Component Name']}
                   slug={`/${item.Slug}`}
-                  imageOpen={`/images/components/${item.Slug}_open.svg`}
-                  imageClosed={`/images/components/${item.Slug}_closed.svg`}
+                  defaultImage={`/images/components/${item.Slug}_open.svg`}
+                  hoverImage={`/images/components/${item.Slug}_closed.svg`}
                 />
               </GridItem>
             ))}


### PR DESCRIPTION
AC-17

### Description:

This changes the names of the `ComponentCard` props from `imageOpen` and `imageClosed` to `defaultImage` and `hoverImage` to more accurately describe their purpose and to match the Airtable values. 

See Story: [Jira card](https://sparkbox.atlassian.net/browse/AC-17)

### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
3. Run `npm run lint` to confirm no errors.
4. Run `npm run test` to confirm all tests pass.
7. In terminal: `npm run dev`.
8. Check [localhost:3000](http://localhost:3000/) and make sure that the images still show up as expected.