### PR TITLE
fix: api key access issue

### DIFF
--- a/src/pages/[id].page.jsx
+++ b/src/pages/[id].page.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { Sandpack } from '@codesandbox/sandpack-react';
 import { levelUp } from '@codesandbox/sandpack-themes';
 import Layout from '../components/Layout';
-import getComponentDetails from '../utils/airtable';
+import { getComponentDetails } from '../utils/airtable';
 import RelatedComponents from '../components/RelatedComponents';
 import SpecificationBlock from '../components/SpecificationBlock';
 import Definition from '../components/Definition';

--- a/src/utils/airtable.js
+++ b/src/utils/airtable.js
@@ -12,9 +12,6 @@ Airtable.configure({
   apiKey: process.env.AIRTABLE_API_KEY,
 });
 
-// Initialize a base
-const base = Airtable.base(process.env.AIRTABLE_BASE_ID);
-
 export const fields = {
   COMPONENT_NAME: 'Component Name',
   SLUG: 'Slug',
@@ -38,7 +35,10 @@ export const fields = {
 
 // this function should return all data for the component we are querying
 // (name, code sample, usage guidelines, role, etc.)
-export default function getComponentDetails(componentName) {
+export function getComponentDetails(componentName) {
+  // Initialize a base
+  const base = Airtable.base(process.env.AIRTABLE_BASE_ID);
+
   return new Promise((resolve, reject) => {
     // connect to our table 'Components
     base('Components')
@@ -67,6 +67,9 @@ export default function getComponentDetails(componentName) {
 
 // this function should return title and image data for all components
 export async function getHomePageInfo() {
+  // Initialize a base
+  const base = Airtable.base(process.env.AIRTABLE_BASE_ID);
+
   // connect to our table 'Components
   const records = await base('Components')
     .select({


### PR DESCRIPTION
### Description:

<!-- Add description of work done here -->
For some reason, setting the `base` variable was throwing an error on the home page, but not the component pages. Moving the variable declaration into the `getComponentDetails` and `getHomePageInfo` seems to resolve the issue.

Changing the functions to named exports instead of having one name and one default was done for consistency more than anything.

See Story: [Jira card](https://sparkbox.atlassian.net/browse/AC-19)

### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
7. In terminal: `npm run dev`.
8. Check [localhost:3000](http://localhost:3000/) to make sure you don't get an error about Airtable needing API keys.
9. Navigate to the other components and confirm the same
10. Go to the deploy preview and confirm that no pages error out or are prevented from rendering
