### PR TITLE
fix: use local image files instead of Airtable images

### DIFF
--- a/src/pages/index.page.jsx
+++ b/src/pages/index.page.jsx
@@ -54,8 +54,8 @@ export default function Home({ details }) {
                 <ComponentCard
                   name={item['Component Name']}
                   slug={`/${item.Slug}`}
-                  imageOpen={item[fields.DEFAULT_IMAGE][0].url}
-                  imageClosed={item[fields.HOVER_IMAGE][0].url}
+                  imageOpen={`/images/components/${item.Slug}_open.svg`}
+                  imageClosed={`/images/components/${item.Slug}_closed.svg`}
                 />
               </GridItem>
             ))}


### PR DESCRIPTION
### Description:

<!-- Add description of work done here -->
This fixes an issue with expiring images hosted in Airtable that break the image references over time.

See Story: [Jira card](https://sparkbox.atlassian.net/browse/AC-20)

### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
3. Run `npm run dev` and navigate to http://localhost:3000
4. You may see an error about the Airtable API Key, which is addressed in #165. You can dismiss the error without causing trouble
5. Confirm that the default and hover images load correctly and toggle as expected on hover