### PR TITLE
feat: support drafted/published components

### DIFF
--- a/src/pages/[id].page.jsx
+++ b/src/pages/[id].page.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { Sandpack } from '@codesandbox/sandpack-react';
 import { levelUp } from '@codesandbox/sandpack-themes';
 import Layout from '../components/Layout';
-import { getComponentDetails } from '../utils/airtable';
+import { getAllComponents, getComponentDetails } from '../utils/airtable';
 import RelatedComponents from '../components/RelatedComponents';
 import SpecificationBlock from '../components/SpecificationBlock';
 import Definition from '../components/Definition';
@@ -167,22 +167,15 @@ const getRelatedComponents = (details) => {
 };
 
 export async function getStaticPaths() {
+  const components = await getAllComponents();
+
   return {
-    paths: [
-      {
-        params: { id: 'accordion' },
+    paths: components.map((component) => ({
+      params: {
+        id: component.Slug,
       },
-      {
-        params: { id: 'dialog' },
-      },
-      {
-        params: { id: 'disclosure' },
-      },
-      {
-        params: { id: 'tabs' },
-      },
-    ],
-    fallback: 'blocking', // indicates the type of fallback
+    })),
+    fallback: false,
   };
 }
 

--- a/src/pages/index.page.jsx
+++ b/src/pages/index.page.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Layout from '../components/Layout';
 import Header from '../components/Header';
 import ComponentCard from '../components/ComponentCard';
-import { getHomePageInfo, fields } from '../utils/airtable';
+import { getAllComponents, fields } from '../utils/airtable';
 import GridItem from '../components/GridItem';
 
 export default function Home({ details }) {
@@ -78,7 +78,7 @@ export default function Home({ details }) {
 export async function getStaticProps() {
   try {
     // run the airtable function to get the data and save to the details variable.
-    const details = await getHomePageInfo();
+    const details = await getAllComponents();
 
     // pass that details variable and its data into props to use elsewhere
     return {

--- a/src/utils/airtable.js
+++ b/src/utils/airtable.js
@@ -66,7 +66,7 @@ export function getComponentDetails(componentName) {
 }
 
 // this function should return title and image data for all components
-export async function getHomePageInfo() {
+export async function getAllComponents() {
   // Initialize a base
   const base = Airtable.base(process.env.AIRTABLE_BASE_ID);
 
@@ -76,12 +76,20 @@ export async function getHomePageInfo() {
       sort: [{ field: 'Component Name', direction: 'asc' }],
     })
     .all();
-  const homePageInfo = records.map((record) => {
-    if (!record.fields['Default Image']) {
-      // Add coming soon image
-    }
-    return record.fields;
-  });
+  const homePageInfo = records
+    .filter((record) => {
+      if (process.env.NODE_ENV === 'development') {
+        return true;
+      }
+
+      return record.fields.Published;
+    })
+    .map((record) => {
+      if (!record.fields['Default Image']) {
+        // Add coming soon image
+      }
+      return record.fields;
+    });
 
   return homePageInfo;
 }


### PR DESCRIPTION
### Description:

<!-- Add description of work done here -->
This adds support for controlling whether components are published in Airtable. In development environments, drafts are shown, but production environments will filter drafted components out.

This required changing `fallback` to false in `getStaticProps`, since we should want components to 404 if they haven't been published. We are also dynamically generating the paths instead of hard-coding known components, giving us more flexibility for adding components.

In Airtable, there is a new column called "Published" that is boolean and drives this behavior.

See Story: [Jira card](https://sparkbox.atlassian.net/browse/AC-9)

### To Validate:

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, etc).
2. Pull down all related branches.
3. In Airtable, make sure at least one of the components is not published
4. Run `npm run export`
5. Run `npm start`
6. Go to http://localhost:3000 and confirm that the unpublished component(s) do not appear in the grid.
7. Go to the details page for the missing component, `/tabs` for example and confirm that it 404s
8. Confirm the same in the deploy preview, provided that the component was not published when it was built
9. Stop the server, then run `npm run dev`
10. Go to the same pages, this time confirming that you can see all of the components and their detail pages