### PR TITLE
feat: Add Google Tag Manager

### DIFF
--- a/src/pages/_document.page.jsx
+++ b/src/pages/_document.page.jsx
@@ -3,10 +3,29 @@ import { Html, Head, Main, NextScript } from 'next/document';
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        {/* eslint-disable-next-line @next/next/next-script-for-ga */}
+        <script
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{
+            __html: `
+                (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
+                var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+                j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+                f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KQ53HCR');
+              `,
+          }}
+        />
+      </Head>
       <body>
         <Main />
         <NextScript />
+        <noscript
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{
+            __html: `<iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KQ53HCR" height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
+          }}
+        />
       </body>
     </Html>
   );


### PR DESCRIPTION
### Description:

Adds Google Tag Manager so the Outreach team can collect Analytics data.

See Story: [SC-1719](https://sparkbox.atlassian.net/browse/SC-1719)

### To Validate:

1. Make sure all PR Checks have passed - the commit check isn't going to pass because this isn't an `AC-` prefixed card, it's a `SC-` prefixed card.
2. Open the [Netlify Deploy Preview](https://deploy-preview-213--accessible-components-cheatsheet.netlify.app/)
3. Inspect the code and confirm that you see Google Tag Manager scripts in the head, and a noscript in the body, that match the code snippets Kaitlyn gave us in the card

![gtm-accessible-components](https://github.com/sparkbox/accessible-components/assets/23404383/65e6fe77-8ee9-4f8a-bd77-96df952d079d)

[SC-1719]: https://sparkbox.atlassian.net/browse/SC-1719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ