### PR TITLE
chore: remove ticket number check from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,15 +24,6 @@ jobs:
           excludeTitle: 'true'
           checkAllCommitMessages: 'true'
           accessToken: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check commit message ticket number
-        uses: gsactions/commit-message-checker@v1
-        with:
-          pattern: 'AC-[0-9]+$'
-          error: 'Commit messages must end with a ticket number.'
-          excludeDescription: 'true'
-          excludeTitle: 'true'
-          checkAllCommitMessages: 'true'
-          accessToken: ${{ secrets.GITHUB_TOKEN }}
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description:

<!-- Add a description of work done here -->
Since this project is not under active development tracking tickets, we can remove the ticket number check from CI.

### To Validate:

Make sure all PR Checks have passed
<!-- Add additional steps for validation here -->
